### PR TITLE
initial import of spectator docs

### DIFF
--- a/src/main/paradox/index.md
+++ b/src/main/paradox/index.md
@@ -8,6 +8,8 @@
 * [Stack Language](asl/index.md)
 * [Reference](asl-reference/index.md)
 * [Spectator](spectator/index.md)
+* [Spectator Extenstions](spectator-ext/index.md)
+* [Spectator Registries](spectator-reg/index.md)
 
 @@@
 

--- a/src/main/paradox/spectator-ext/index.md
+++ b/src/main/paradox/spectator-ext/index.md
@@ -1,0 +1,16 @@
+@@@ index
+
+* [JVM Buffer Pools](jvm-buffer-pools.md)
+* [JVM GC](jvm-gc.md)
+* [JVM GC Causes](jvm-gc-causes.md)
+* [JVM Memory Pools](jvm-memory-pools.md)
+* [JVM Thread Pools](thread-pools.md)
+* [Log4j 1](log4j1.md)
+* [Log4j 2](log4j2.md)
+* [Placeholders](placeholders.md)
+
+@@@
+
+# Spectator Extensions
+
+

--- a/src/main/paradox/spectator-ext/jvm-buffer-pools.md
+++ b/src/main/paradox/spectator-ext/jvm-buffer-pools.md
@@ -1,0 +1,42 @@
+# Buffer Pools
+
+Buffer pools, such as direct byte buffers, can be monitored at a high level using the
+[BufferPoolMXBean](http://docs.oracle.com/javase/7/docs/api/java/lang/management/BufferPoolMXBean.html)
+provided by the JDK. 
+
+## Getting Started
+
+To get information about buffer pools in spectator just setup registration of standard MXBeans.
+Note, if you are building an app at Netflix this should happen automatically via the normal
+platform initialization.
+
+```java
+import com.netflix.spectator.api.Spectator;
+import com.netflix.spectator.jvm.Jmx;
+
+Jmx.registerStandardMXBeans(Spectator.registry());
+```
+
+## Metrics
+
+### jvm.buffer.count
+
+Gauge showing the current number of distinct buffers.
+
+**Unit:** count 
+
+**Dimensions:**
+
+* `id`: type of buffers. Value will be either `direct` for direct byte buffers or `mapped` for
+  memory mapped files.
+
+### jvm.buffer.memoryUsed
+
+Gauge showing the current number of bytes used by all buffers.
+
+**Unit:** bytes 
+
+**Dimensions:**
+
+* `id`: type of buffers. Value will be either `direct` for direct byte buffers or `mapped` for
+  memory mapped files.

--- a/src/main/paradox/spectator-ext/jvm-gc-causes.md
+++ b/src/main/paradox/spectator-ext/jvm-gc-causes.md
@@ -1,0 +1,157 @@
+# GC Causes
+
+The various GC causes aren't well documented. The list provided here comes from the
+[gcCause.cpp](http://hg.openjdk.java.net/jdk8u/hs-dev/hotspot/file/tip/src/share/vm/gc_interface/gcCause.cpp)
+file in the jdk and we include some information on what these mean for the application.
+
+### System.gc__
+
+Something called [System.gc()](http://docs.oracle.com/javase/7/docs/api/java/lang/System.html#gc()).
+If you are seeing this once an hour it is likely related to the RMI GC interval. For more
+details see:
+
+* [Unexplained System.gc() calls due to Remote Method Invocation (RMI) or explict garbage collections](http://www-01.ibm.com/support/docview.wss?uid=swg21173431)
+* [sun.rmi.dgc.client.gcInterval](http://docs.oracle.com/javase/6/docs/technotes/guides/rmi/sunrmiproperties.html)
+
+### FullGCAlot
+
+Most likely you'll never see this value. In debug builds of the jdk there is an option,
+`-XX:+FullGCALot`, that will trigger a full GC at a regular interval for testing purposes.
+
+### ScavengeAlot
+
+Most likely you'll never see this value. In debug builds of the jdk there is an option,
+`-XX:+ScavengeALot`, that will trigger a minor GC at a regular interval for testing purposes.
+
+### Allocation_Profiler
+
+Prior to java 8 you would see this if running with the `-Xaprof` setting. It would be triggered
+just before the jvm exits. The `-Xaprof` option was removed in java 8.
+
+### JvmtiEnv_ForceGarbageCollection
+
+Something called the JVM tool interface function
+[ForceGarbageCollection](https://docs.oracle.com/javase/8/docs/platform/jvmti/jvmti.html#ForceGarbageCollection).
+Look at the `-agentlib` param to java to see what agents are configured.
+
+### GCLocker_Initiated_GC
+
+The GC locker prevents GC from occurring when JNI code is in a
+[critical region](http://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/functions.html#GetPrimitiveArrayCritical_ReleasePrimitiveArrayCritical).
+If GC is needed while a thread is in a critical region, then it will allow them to complete,
+i.e. call the corresponding release function. Other threads will not be permitted to enter a
+critical region. Once all threads are out of critical regions a GC event will be triggered. 
+
+### Heap_Inspection_Initiated_GC
+
+GC was initiated by an inspection operation on the heap. For example you can trigger this
+with [jmap](http://docs.oracle.com/javase/7/docs/technotes/tools/share/jmap.html):
+
+`$ jmap -histo:live <pid>`
+
+### Heap_Dump_Initiated_GC
+
+GC was initiated before dumping the heap. For example you can trigger this with
+[jmap](http://docs.oracle.com/javase/7/docs/technotes/tools/share/jmap.html):
+
+`$ jmap -dump:live,format=b,file=heap.out <pid>`
+
+Another common example would be clicking the Heap Dump button on the Monitor tab in
+[jvisualvm](http://docs.oracle.com/javase/7/docs/technotes/tools/share/jvisualvm.html).
+
+### WhiteBox_Initiated_Young_GC
+
+Most likely you'll never see this value. Used for testing hotspot, it indicates something
+called `sun.hotspot.WhiteBox.youngGC()`. 
+
+### No_GC
+
+Used for CMS to indicate concurrent phases.
+
+### Allocation_Failure
+
+Usually this means that there is an allocation request that is bigger than the available space
+in young generation and will typically be associated with a minor GC. For G1 this will likely
+be a major GC and it is more common to see [G1_Evacuation_Pause](#g1_evacuation_pause) for
+routine minor collections.
+
+On linux the jvm will trigger a GC if the kernel indicates there isn't much memory left via
+[mem_notify](http://lwn.net/Articles/267013/).
+
+### Tenured_Generation_Full
+
+Not used?
+
+### Permanent_Generation_Full
+
+Triggered as a result of an allocation failure in
+[PermGen](https://blogs.oracle.com/poonam/entry/about_g1_garbage_collector_permanent). Pre java 8.
+
+### Metadata_GC_Threshold
+
+Triggered as a result of an allocation failure in
+[Metaspace](https://blogs.oracle.com/poonam/entry/about_g1_garbage_collector_permanent).
+Metaspace replaced PermGen was added in java 8.
+
+### CMS_Generation_Full
+
+Not used?
+
+### CMS_Initial_Mark
+
+Initial mark phase of CMS, for more details see
+[Phases of CMS](https://blogs.oracle.com/jonthecollector/entry/hey_joe_phases_of_cms).
+Unfortunately it doesn't appear to be reported via the mbeans and we just get [No_GC](#no_gc).
+
+### CMS_Final_Remark
+
+Remark phase of CMS, for more details see
+[Phases of CMS](https://blogs.oracle.com/jonthecollector/entry/hey_joe_phases_of_cms).
+Unfortunately it doesn't appear to be reported via the mbeans and we just get [No_GC](#no_gc).
+
+### CMS_Concurrent_Mark
+
+Concurrent mark phase of CMS, for more details see
+[Phases of CMS](https://blogs.oracle.com/jonthecollector/entry/hey_joe_phases_of_cms).
+Unfortunately it doesn't appear to be reported via the mbeans and we just get [No_GC](#no_gc).
+
+### Old_Generation_Expanded_On_Last_Scavenge
+
+Not used?
+
+### Old_Generation_Too_Full_To_Scavenge
+
+Not used?
+
+### Ergonomics
+
+This indicates you are using the adaptive size policy, `-XX:+UseAdaptiveSizePolicy` and is
+on by default for recent versions, with the parallel collector (`-XX:+UseParallelGC`). For
+more details see [The Why of GC Ergonomics](https://blogs.oracle.com/jonthecollector/entry/the_unspoken_the_why_of).
+
+### G1_Evacuation_Pause
+
+An evacuation pause is the most common young gen cause for G1 and indicates that it is copying
+live objects from one set of regions, young and sometimes young + old, to another set of
+regions. For more details see [Understanding G1 GC Logs](https://blogs.oracle.com/poonam/entry/understanding_g1_gc_logs).
+
+### G1_Humongous_Allocation
+
+A humongous allocation is one where the size is greater than 50% of the G1 region size. Before
+a humongous allocation the jvm checks if it should do a routine
+[evacuation pause](#g1_evacuation_pause) without regard to the actual allocation size, but if
+triggered due to this check the cause will be listed as humongous allocation. This cause is
+also used for any collections used to free up enough space for the allocation. 
+
+### Last_ditch_collection
+
+For perm gen (java 7 or earlier) and metaspace (java 8+) a last ditch collection will be
+triggered if an allocation fails and the memory pool cannot be expanded.
+
+### ILLEGAL_VALUE_-_last_gc_cause_-_ILLEGAL_VALUE
+
+Included for completeness, but you should never see this value.
+
+### unknown_GCCause
+
+Included for completeness, but you should never see this value.

--- a/src/main/paradox/spectator-ext/jvm-gc.md
+++ b/src/main/paradox/spectator-ext/jvm-gc.md
@@ -1,0 +1,181 @@
+# Garbage Collection
+
+The GC module registers with the notification emitter of the
+[GarbageCollectorMXBean](http://docs.oracle.com/javase/7/docs/api/java/lang/management/GarbageCollectorMXBean.html)
+to provide some basic GC logging and metrics.
+
+* [Getting started](#getting-started)
+* [Logging](#logging)
+* [Metrics](#metrics)
+* [Alerting](#alerting)
+
+## Getting Started
+
+For using it internally at Netflix see the [Netflix integration](../intro/netflix.md) guide,
+otherwise keep reading this section.
+
+### Requirements
+
+This library relies on the notification emitter added in 7u4, but there are known issues prior
+to 7u40. There is also a regression impacting java 9 and higher, see [#502] and [JDK-8196325]
+for more information. For G1 it is recommended to be on the latest version available.
+
+[#502]: https://github.com/Netflix/spectator/issues/502
+[JDK-8196325]: https://bugs.openjdk.java.net/browse/JDK-8196325
+
+### Dependencies
+
+```
+com.netflix.spectator:spectator-ext-gc:0.62.0
+```
+
+### Start Reporting
+
+Then in the initialization for the application:
+
+```java
+import com.netflix.spectator.gc.GcLogger;
+...
+// Keep a single instance of the logger
+GcLogger gc = new GcLogger();
+gc.start(null);
+```
+
+## Logging
+
+After GC events an INFO level log message will get reported using slf4j. This makes it easy to
+GC events in the context of other log messages for the application. The logger name is
+`com.netflix.spectator.gc.GcLogger` and the message will look like:
+
+```
+${GC_TYPE}: ${COLLECTOR_NAME}, id=${N}, at=${START_TIME}, duration=${T}ms, cause=[${CAUSE}], ${TOTAL_USAGE_BEFORE} => ${TOTAL_USAGE_AFTER} / ${MAX_SIZE} (${PERCENT_USAGE_BEFORE} => ${PERCENT_USAGE_AFTER})
+```
+
+The id can be used to verify events were not skipped or correlate with other sources like
+detailed GC logs. See [GC causes](jvm-gc-causes.md) for more details on the possible causes.
+
+Sample:
+
+```
+2014-08-31 02:02:24,724  INFO [com.netflix.spectator.gc.GcLogger] YOUNG: ParNew, id=5281, at=Sun Aug 31 02:02:24 UTC 2014, duration=2ms, cause=[Allocation Failure], 0.4G => 0.3G / 1.8G (24.3% => 16.6%)
+```
+
+## Metrics
+
+### jvm.gc.allocationRate
+
+The allocation rate measures how fast the application is allocating memory. It is a counter
+that is incremented after a GC event by the amount `youngGen.sizeBeforeGC`. Technically, right
+now it is:
+
+`youngGen.sizeBeforeGC - youngGen.sizeAfterGC`
+
+However, `youngGen.sizeAfterGC` should be 0 and thus the size of young gen before the GC is
+the amount allocated since the previous GC event.
+
+**Unit:** bytes/second
+
+**Dimensions:** n/a
+
+### jvm.gc.promotionRate
+
+The promotion rate measures how fast data is being moved from young generation into the old
+generation. It is a counter that is incremented after a GC event by the amount:
+
+`abs(oldGen.sizeAfterGC - oldGen.sizeBeforeGC)`
+
+**Unit:** bytes/second
+
+**Dimensions:** n/a
+
+### jvm.gc.liveDataSize
+
+The live data size is the size of the old generation after a major GC. The image below shows
+how the live data size view compares to a metric showing the current size of the memory pool:
+
+![Live Data Size](../images/live_data_size.png)
+
+**Unit:** bytes
+
+**Dimensions:** n/a
+
+### jvm.gc.maxDataSize
+
+Maximum size for the old generation. Primary use-case is for gaining perspective on the the
+live data size.
+
+**Unit:** bytes
+
+**Dimensions:** n/a
+
+### jvm.gc.pause
+
+Timer reporting the pause time for a GC event. All of the values reported are stop the world
+pauses.
+
+**Unit:**
+
+* `statistic=max`: seconds
+* `statistic=count`: events/second
+* `statistic=totalTime`: seconds/second
+
+**Dimensions:**
+
+* `action`: action performed by the garbage collector
+   ([javadoc](http://docs.oracle.com/javase/7/docs/jre/api/management/extension/com/sun/management/GarbageCollectionNotificationInfo.html#getGcAction())).
+   There is no guarantee, but the typical values seen are `end_of_major_GC` and `end_of_minor_GC`.
+* `cause`: cause that instigated GC ([javadoc](http://docs.oracle.com/javase/7/docs/jre/api/management/extension/com/sun/management/GarbageCollectionNotificationInfo.html#getGcCause())).
+  For an explanation of common causes see the [GC causes](jvm-gc-causes.md) page.
+
+### jvm.gc.concurrentPhaseTime
+
+Timer reporting time spent in concurrent phases of CMS.
+pauses.
+
+**Unit:**
+
+* `statistic=max`: seconds
+* `statistic=count`: events/second
+* `statistic=totalTime`: seconds/second
+
+**Dimensions:**
+
+* `action`: action performed by the garbage collector
+  ([javadoc](http://docs.oracle.com/javase/7/docs/jre/api/management/extension/com/sun/management/GarbageCollectionNotificationInfo.html#getGcAction())).
+  There is no guarantee, but the typical values seen are `end_of_major_GC` and `end_of_minor_GC`.
+* `cause`: cause that instigated GC ([javadoc](http://docs.oracle.com/javase/7/docs/jre/api/management/extension/com/sun/management/GarbageCollectionNotificationInfo.html#getGcCause())).
+  For an explanation of common causes see the [GC causes](jvm-gc-causes.md) page.
+
+## Alerting
+
+This section assumes the data is available in [Atlas](https://github.com/Netflix/atlas/wiki/),
+but users of other systems should be able to take the idea and make it work. For all of these
+alerts it is recommended to check them on instance. At Netflix that can be done by selecting
+the option in alert ui:
+
+> ![On Instance Alerting](../images/on_instance.png)
+
+### Max Pause Time
+
+Example to trigger an alert if the [pause time](#jvmgcpause) exceeds 500 milliseconds:
+
+```
+name,jvm.gc.pause,:eq,
+statistic,max,:eq,
+:and,
+:max,(,cause,),:by,
+0.5,:gt,
+$cause,:legend
+``` 
+
+### Heap Pressure
+
+Example to trigger an alert if the [live data size](#jvmgclivedatasize) is over 70% of the heap:
+
+```
+name,jvm.gc.liveDataSize,:eq,:max,
+name,jvm.gc.maxDataSize,:eq,:max,
+:div,100,:mul,
+70,:gt,
+percentUsed,:legend
+``` 

--- a/src/main/paradox/spectator-ext/jvm-memory-pools.md
+++ b/src/main/paradox/spectator-ext/jvm-memory-pools.md
@@ -1,0 +1,75 @@
+# Memory Pools
+
+Uses the [MemoryPoolMXBean](http://docs.oracle.com/javase/7/docs/api/java/lang/management/MemoryPoolMXBean.html)
+provided by the JDK to monitor the sizes of java memory spaces such as perm gen, eden, old
+gen, etc. 
+
+## Getting Started
+
+To get information about memory pools in spectator just setup registration of standard MXBeans.
+Note, if you are building an app at Netflix this should happen automatically via the normal
+platform initialization.
+
+```java
+import com.netflix.spectator.api.Spectator;
+import com.netflix.spectator.jvm.Jmx;
+
+Jmx.registerStandardMXBeans(Spectator.registry());
+```
+
+## Metrics
+
+### jvm.memory.used
+
+Gauge reporting the current amount of memory used. For the young and old gen pools this
+metric will typically have a sawtooth pattern. For alerting or detecting memory pressure
+the [live data size](https://github.com/Netflix/spectator/wiki/Garbage-Collection#jvmgclivedatasize)
+is probably a better option.
+
+**Unit:** bytes
+
+**Dimensions:**
+see [metric dimensions](#metric-dimensions)
+
+### jvm.memory.committed
+
+Gauge reporting the current amount of memory committed. From the
+[javadocs](http://docs.oracle.com/javase/7/docs/api/java/lang/management/MemoryUsage.html),
+committed is:
+
+> The amount of memory (in bytes) that is guaranteed to be available for use by the Java
+> virtual machine. The amount of committed memory may change over time (increase or decrease).
+> The Java virtual machine may release memory to the system and committed could be less than
+> init. committed will always be greater than or equal to used.
+
+**Unit:** bytes 
+
+**Dimensions:**
+see [metric dimensions](#metric-dimensions)
+
+### jvm.memory.max
+
+Gauge reporting the max amount of memory that can be used. From the
+[javadocs](http://docs.oracle.com/javase/7/docs/api/java/lang/management/MemoryUsage.html),
+max is:
+
+> The maximum amount of memory (in bytes) that can be used for memory management. Its value
+> may be undefined. The maximum amount of memory may change over time if defined. The amount
+> of used and committed memory will always be less than or equal to max if max is defined. A
+> memory allocation may fail if it attempts to increase the used memory such that
+> `used > committed` even if `used <= max` would still be true (for example, when the
+> system is low on virtual memory).
+
+**Unit:** bytes 
+
+**Dimensions:**
+see [metric dimensions](#metric-dimensions)
+
+## Metric Dimensions
+
+All memory metrics have the following dimensions:
+
+* `id`: name of the memory pool being reported. The names of the pools vary depending on the
+  garbage collector algorithm being used.
+* `memtype`: type of memory. It has two possible values: `HEAP` and `NON_HEAP`. For more
+  information see the javadocs for [MemoryType](http://docs.oracle.com/javase/7/docs/api/java/lang/management/MemoryType.html).

--- a/src/main/paradox/spectator-ext/log4j1.md
+++ b/src/main/paradox/spectator-ext/log4j1.md
@@ -1,0 +1,50 @@
+# Log4j1 Appender
+
+Custom appender for [log4j1](http://logging.apache.org/log4j/1.2/) to track the number of
+log messages reported. 
+
+!!! note
+    Log4j 1.x has reached [end of life][eol] and is no longer supported by Apache. This extension
+    is provided for some users that have difficulty moving to a supported version of log4j.
+    
+[eol]: https://blogs.apache.org/foundation/entry/apache_logging_services_project_announces
+
+## Getting Started
+
+To use it simply add a dependency:
+
+```
+com.netflix.spectator:spectator-ext-log4j1:0.62.0
+```
+
+Then in your log4j configuration specify the `com.netflix.spectator.log4j.SpectatorAppender`.
+In a properties file it would look something like:
+
+```
+log4j.rootLogger=ALL, A1
+log4j.appender.A1=com.netflix.spectator.log4j.SpectatorAppender
+```
+
+## Metrics
+
+### log4j.numMessages
+
+Counters showing the number of messages that have been passed to the appender.
+
+**Unit:** messages/second
+
+**Dimensions:**
+
+* `loglevel`: standard log level of the events.
+
+### log4j.numStackTraces
+
+Counter for the number of messages with stack traces written to the logs.
+
+**Unit:** messages/second
+
+**Dimensions:**
+
+* `loglevel`: standard log level of the events.
+* `exception`: simple class name for the exception that was thrown.
+* `file`: file name for where the exception was thrown.

--- a/src/main/paradox/spectator-ext/log4j2.md
+++ b/src/main/paradox/spectator-ext/log4j2.md
@@ -1,0 +1,70 @@
+# Log4j2 Appender
+
+Custom appender for [log4j2](http://logging.apache.org/log4j/2.x/) to track the number of
+log messages reported. 
+
+## Getting Started
+
+To use it simply add a dependency:
+
+```
+com.netflix.spectator:spectator-ext-log4j2:0.62.0
+```
+
+Then in your application initialization:
+
+```java
+Registry registry = ...
+SpectatorAppender.addToRootLogger(
+    registry,             // Registry to use
+    "spectator",          // Name for the appender
+    false);               // Should stack traces be ignored?
+```
+
+This will add the appender to the root logger and register a listener so it will get
+re-added if the configuration changes. You can also use the appender by specifying it
+in the log4j2 configuration, but this will cause some of the loggers in Spectator to get
+created before log4j is properly initialized and result in some lost log messages. With
+that caveat in mind, if you need the additional flexibility of using the configuration then
+specify the `Spectator` appender:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration monitorInterval="5" status="warn">
+  <Appenders>
+    <Spectator name="root"/>
+  </Appenders>
+  <Loggers>
+    <Root level="debug">
+      <AppenderRef ref="root"/>
+    </Root>
+  </Loggers>
+</Configuration>
+```
+
+## Metrics
+
+### log4j.numMessages
+
+Counters showing the number of messages that have been passed to the appender.
+
+**Unit:** messages/second
+
+**Dimensions:**
+
+* `appender`: name of the spectator appender.
+* `loglevel`: standard log level of the events.
+
+### log4j.numStackTraces
+
+Counter for the number of messages with stack traces written to the logs. This will only be
+collected if the `ignoreExceptions` flag is set to false for the appender.
+
+**Unit:** messages/second
+
+**Dimensions:**
+
+* `appender`: name of the spectator appender.
+* `loglevel`: standard log level of the events.
+* `exception`: simple class name for the exception that was thrown.
+* `file`: file name for where the exception was thrown.

--- a/src/main/paradox/spectator-ext/placeholders.md
+++ b/src/main/paradox/spectator-ext/placeholders.md
@@ -1,0 +1,101 @@
+# Placeholders
+
+The placeholders extension allows for identifiers to be created with dimensions that
+will get filled in based on the context when an activity occurs. The primary use-cases
+are to support:
+
+1. Optional dimensions that can be conditionally enabled.
+2. Pulling dimensions from another context such as a thread local store. This can make
+   it is easier to share the across various parts of the code.
+   
+## Dependencies
+
+To use the placeholders support add a dependency on:
+
+```
+com.netflix.spectator:spectator-ext-placeholders:0.62.0
+```
+
+## Usage
+
+Placeholder support is available for activity based types including
+[counters](../intro/counter.md), [timers](../intro/timer.md), and
+[distribution summaries](../intro/dist-summary.md). To get started create a
+`PlaceholderFactory` from the registry:
+
+```java
+PlaceholderFactory factory = PlaceholderFactory.from(registry);
+```
+
+Then use the factory to create an identifier using a `TagFactory` to dynamically fetch
+the value for a given dimension when some activity occurs. Suppose we want to use a
+dynamic configuration library such as [Archaius](https://github.com/Netflix/archaius/tree/2.x)
+to conditionally enable a dimension with high cardinality:
+
+```java
+public class Server {
+  
+  private final Context context;
+  private final Counter rps;
+  
+  public Server(Context context, PropertyFactory props, Registry registry) {
+    this.context = context;
+    
+    // Property that can be dynamically updated to indicate whether or not
+    // detailed dimensions should be added to metrics.
+    Property<Boolean> enabled = props
+      .getProperty("server.detailedMetricsEnabled")
+      .asBoolean(false);
+      
+    // Factory for creating instances of the counter using placeholders
+    PlaceholderFactory factory = PlaceholderFactory.from(registry);
+    
+    // Create the underlying id with 4 possible dimensions:
+    // *  method and status - low cardinality and always added if available
+    //    in the context.
+    // *  geo and device - high cardinality and only available if the property
+    //    to enable detailed metrics is set to true.
+    PlaceholderId rpsId = factory.createId("server.requests")
+      .withTagFactory(TagFactory.from("method", context::getMethod))
+      .withTagFactory(TagFactory.from("status", context::getStatus))
+      .withTagFactory(new DetailedDimension("geo", enabled, context::getGeo))
+      .withTagFactory(new DetailedDimension("device", enabled, context::getDevice));
+    rps = factory.counter(rpsId);
+  }
+  
+  public Response handle(Request request) {
+    fillInContext(request);
+    Response response = process(request);
+    fillInContext(response);
+    
+    // Update the counter, the placeholders will be resolved when the activity, in
+    // this case the increment is called.
+    rps.increment();
+    return response;
+  }
+ 
+  // Tag factory that can be controlled with an enabled property.
+  private static class DetailedDimension implements TagFactory {
+    
+    private final String name;
+    private final Supplier<String> valueFunc;
+    
+    DetailedDimension(String name, Property<Boolean> enabled, Supplier<String> valueFunc) {
+      this.name = name;
+      this.enabled = enabled;
+      this.valueFunc = valueFunc;
+    }
+    
+    @Override public String name() {
+      return name;
+    }
+    
+    @Override public Tag createTag() {
+      return enabled.get()
+          ? new BasicTag(name, valueFunc.get())
+          : null;
+    }
+  }
+}
+```
+

--- a/src/main/paradox/spectator-ext/thread-pools.md
+++ b/src/main/paradox/spectator-ext/thread-pools.md
@@ -1,0 +1,72 @@
+# Thread Pools
+
+Java's [ThreadPoolExecutor] exposes several properties that are useful to monitor to assess
+the health, performance, and configuration of the pool.
+
+## Getting Started
+
+To report thread pool metrics, one can attach a [ThreadPoolMonitor] in the following manner:
+
+```java
+import com.netflix.spectator.api.patterns.ThreadPoolMonitor;
+
+ThreadPoolMonitor.attach(registry, myThreadPoolExecutor, "my-thread-pool");
+```
+
+The thread pool's properties will be polled regularly in the background and will report metrics to the provided
+registry. The third parameter will be added to each metric as an `id` dimension, if provided. However, if the value is
+`null` or an empty string, then a default will be used as the `id`.
+
+## Metrics
+
+### threadpool.taskCount
+
+Counter of the total number of tasks that have been scheduled.
+
+**Unit:** tasks/second<br/>
+**Data Source:** `ThreadPoolExecutor#getTaskCount()`
+
+### threadpool.completedTaskCount
+
+Counter of the total number of tasks that have completed.
+
+**Unit:** tasks/second<br/>
+**Data Source:** `ThreadPoolExecutor#getCompletedTaskCount()`
+
+### threadpool.currentThreadsBusy
+
+Gauge showing the current number of threads actively doing work.
+
+**Unit:** count<br/>
+**Data Source:** `ThreadPoolExecutor#getActiveCount()`
+
+### threadpool.maxThreads
+
+Gauge showing the current maximum number of threads configured for the pool.
+
+**Unit:** count<br/>
+**Data Source:** `ThreadPoolExecutor#getMaximumPoolSize()`
+
+### threadpool.poolSize
+
+Gauge showing the current size of the pool.
+
+**Unit:** count<br/>
+**Data Source:** `ThreadPoolExecutor#getPoolSize()`
+
+### threadpool.corePoolSize
+
+Gauge showing the current maximum number of core threads configured for the pool.
+
+**Unit:** count<br/>
+**Data Source:** `ThreadPoolExecutor#getCorePoolSize()`
+
+### threadpool.queueSize
+
+Gauge showing the current number of threads queued for execution.
+
+**Unit:** count<br/>
+**Data Source:** `ThreadPoolExecutor#getQueue().size()`
+
+[ThreadPoolExecutor]: http://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ThreadPoolExecutor.html
+[ThreadPoolMonitor]: http://netflix.github.io/spectator/en/latest/javadoc/spectator-api/com/netflix/spectator/api/patterns/ThreadPoolMonitor.html

--- a/src/main/paradox/spectator-reg/index.md
+++ b/src/main/paradox/spectator-reg/index.md
@@ -1,0 +1,10 @@
+@@@ index
+
+* [Metrics 3](metrics3.md)
+* [Servo](servo.md)
+
+@@@
+
+# Spectator Registries
+
+

--- a/src/main/paradox/spectator-reg/metrics3.md
+++ b/src/main/paradox/spectator-reg/metrics3.md
@@ -1,0 +1,12 @@
+# Metrics3 Registry
+
+Registry that uses [metrics3](http://metrics.dropwizard.io/3.1.0/) as the
+underlying implementation. To use the metrics registry, add a dependency on the
+`spectator-reg-metrics3` library. For gradle:
+
+```
+com.netflix.spectator:spectator-reg-metrics3:0.62.0
+```
+
+Then when initializing the application, use the `MetricsRegistry`. For more
+information see the [metrics3 example](https://github.com/brharrington/spectator-examples/tree/master/metrics3).

--- a/src/main/paradox/spectator-reg/servo.md
+++ b/src/main/paradox/spectator-reg/servo.md
@@ -1,0 +1,28 @@
+# Servo Registry
+
+Registry that uses [servo](https://github.com/Netflix/servo) as the underlying
+implementation. To use the servo registry, add a dependency on the
+`spectator-reg-servo` library. For gradle:
+
+```
+com.netflix.spectator:spectator-reg-servo:0.62.0
+```
+
+Then when initializing the application, use the `ServoRegistry`. If using guice
+then that would look like:
+
+```java
+Injector injector = Guice.createInjector(new AbstractModule() {
+    @Override protected void configure() {
+    }
+
+    @Provides
+    @Singleton
+    private Registry providesRegistry() {
+      return new ServoRegistry();
+    }
+  });
+```
+
+For more information see the [servo example](https://github.com/brharrington/spectator-examples/tree/master/servo). Note if running internally at Netflix see the
+[Netflix Integration](../intro/netflix.md) docs instead.

--- a/src/main/paradox/spectator/clock.md
+++ b/src/main/paradox/spectator/clock.md
@@ -1,0 +1,81 @@
+# Clock
+
+When taking measurements or working with timers it is recommended to use the
+[clock](http://netflix.github.io/spectator/en/latest/javadoc/spectator-api/com/netflix/spectator/api/Clock.html)
+interface. It provides two methods for measuring time:
+
+## Wall Time
+
+This is what most users think of for time. It can be used to get the current
+time like what you would see on a wall clock. In most cases when not running
+in tests this will call [System.currentTimeMillis()](https://docs.oracle.com/javase/8/docs/api/java/lang/System.html#currentTimeMillis--).
+
+Note that the values returned by this method may not be monontonically increasing.
+Just like a clock on your wall, this value can go back in time or jump forward
+at unpredictable intervals if someone sets the time. On many systems
+[ntpd](https://en.wikipedia.org/wiki/Ntpd) will be constantly keeping the time
+synced up with an authoritative source.
+
+With spectator, the clock is typically accessed via the [regstry](registry.md).
+Example of usage:
+
+```java
+// Current time in milliseconds since the epoch
+long currentTime = registry.clock().wallTime();
+```
+
+## Monotonic Time
+
+While it is good in general for the wall clock to show the correct time, the
+unpredictable changes mean it is not a good choice for measuring how long an
+operation took. Consider a simple example of measuring request latency on a
+server:
+
+```java
+long start = registry.clock().wallTime();
+handleRequest(request, response);
+long end = registry.clock().wallTime();
+reqLatencyTimer.record(end - start, TimeUnit.MILLISECONDS);
+```
+
+If ntp fixes the server time between `start` and `end`, then the recorded
+latency will be wrong. Spectator will protect against obviously wrong
+measurements like negative latencies by dropping those values when they are
+recorded. However, the change could incorrectly shorten or lengthen the
+measured latency.
+
+The clock interface also provides access to a monotonic source that is
+only useful for measuring elapsed time, for example:
+
+```java
+long start = registry.clock().monotonicTime();
+handleRequest(request, response);
+long end = registry.clock().monotonicTime();
+reqLatencyTimer.record(end - start, TimeUnit.NANOSECONDS);
+```
+
+In most cases this will map to
+[System.nanoTime()](https://docs.oracle.com/javase/8/docs/api/java/lang/System.html#nanoTime--).
+Note the actual value returned is not meaningful unless compared with
+another sample to get a delta.
+
+## Manual Clock
+
+If timing code is written to the clock interface, then alternative implemenations
+can be plugged in. For test cases it is common to use
+[ManualClock](http://netflix.github.io/spectator/en/latest/javadoc/spectator-api/com/netflix/spectator/api/ManualClock.html)
+so that tests can be reliable and fast without having to rely on hacks like sleep or
+assuming something will run in less than a certain amount of time. 
+
+```java
+ManualClock clock = new ManualClock();
+Registry registry = new DefaultRegistry(clock);
+
+Timer timer = registry.timer("test");
+timer.record(() -> {
+  doSomething();
+  clock.setMonotonicTime(42L);
+});
+
+Assert.assertEquals(timer.totalTime(), 42L);
+```

--- a/src/main/paradox/spectator/conventions.md
+++ b/src/main/paradox/spectator/conventions.md
@@ -1,0 +1,96 @@
+Quick summary:
+
+1. Names
+    * Describe the measurement being collected
+    * Use camel case
+    * Static
+    * Succinct
+2. Tags
+    * Should be used for dimensional drill-down
+    * Be careful about combinatorial explosion
+    * Tag keys should be static
+    * Use `id` to distinguish between instances
+3. Use base units
+
+## Names
+
+### Describe the measurement
+
+### Use camel case
+
+The main goal here is to promote consistency which makes it easier for users. The choice of
+style is somewhat arbitrary, camel case was chosen because:
+
+* Used by snmp
+* Used by java
+* It was the most common in use at Netflix when this guideline was added
+
+The exception to this rule is where there is an established common case. For example with
+Amazon regions it is preferred to use us-east-1 rather than usEast1 as it is the more common
+form.
+
+### Static
+
+There shouldn't be any dynamic content that goes into a metric name. Metric names and
+associated tag keys are how users will interact with the data being produced. 
+
+### Succinct
+
+Long names should be avoided. 
+
+## Tags
+
+Historically tags have been used to play one of two roles:
+
+* *Dimensions*: dimensions are the primary use and it allows the data to be sliced and diced so
+  it is possible to drill down into the data.
+* *Namespace*: similar to packages in Java in this mode it would be used to group related data.
+  This type of usage is discouraged.   
+
+As a general rule it should be possible to use the name as a pivot. This means that if
+just the name is selected, then the user can drill down using other dimensions and be
+able to reason about the value being shown. 
+
+As a concrete example, suppose we have two metrics:
+
+1. The number of threads currently in a thread pool.
+2. The number of rows in a database table.
+
+### Bad approach
+
+```java
+Id poolSize = registry.createId("size")
+  .withTag("class", "ThreadPool")
+  .withTag("id", "server-requests");
+  
+Id poolSize = registry.createId("size")
+  .withTag("class", "Database")
+  .withTag("table", "users");  
+```
+
+In this approach, if I select the name, `size`, it will match both the version for 
+ThreadPool and Database classes. So you would get a value that is the an aggregate of the number
+of threads and the number of items in a database. 
+
+### Recommended
+
+```java
+Id poolSize = registry.createId("threadpool.size")
+  .withTag("id", "server-requests");
+  
+Id poolSize = registry.createId("db.size")
+  .withTag("table", "users");  
+```
+
+This variant provides enough context so that if just the name is selected the value can
+be reasoned about and is at least potentially meaningful. For example if I select
+`threadpool.size` I can see the total number of threads in all pools. Then I can group by or
+select an `id` to drill down further.
+
+
+## Use base units
+
+Keep measurements in base units where possible. For example I would rather have all timers
+in seconds, disk sizes should be bytes, or network rates should be bytes/second. The reason
+is that for my uses this usually means the unit is obvious from the name. It also means the
+SI prefix shown on the graph images make more sense, e.g. 1k is 1 kilobyte not 1 kilo-megabyte.

--- a/src/main/paradox/spectator/counters.md
+++ b/src/main/paradox/spectator/counters.md
@@ -1,0 +1,52 @@
+# Counters
+
+A counter is used to measure the rate at which some event is occurring.
+Consider a simple queue, counters would be used to measure things like the
+rate at which items are being inserted and removed. 
+
+Counters are created using the registry which will be setup as part of
+application initialization. For example:
+
+```java
+public class Queue {
+
+  private final Counter insertCounter;
+  private final Counter removeCounter;
+  private final QueueImpl impl;
+
+  @Inject
+  public Queue(Registry registry) {
+    insertCounter = registry.counter("queue.insert");
+    removeCounter = registry.counter("queue.remove");
+    impl = new QueueImpl();
+  }
+```
+
+Then call increment when an event occurs:
+
+```java
+  public void insert(Object obj) {
+    insertCounter.increment();
+    impl.insert(obj);
+  }
+
+  public Object remove() {
+    if (impl.nonEmpty()) {
+      removeCounter.increment();
+      return impl.remove();
+    } else {
+      return null;
+    }
+  }
+```
+
+Optionally an amount can be passed in when calling increment. This is useful
+when a collection of events happens together. 
+
+```java
+  public void insertAll(Collection<Object> objs) {
+    insertCounter.increment(objs.size());
+    impl.insertAll(objs);
+  }
+}
+```

--- a/src/main/paradox/spectator/dist-summaries.md
+++ b/src/main/paradox/spectator/dist-summaries.md
@@ -1,0 +1,32 @@
+# Distribution Summaries
+
+A distribution summary is used to track the distribution of events. It is
+similar to a timer, but more general in that the size does not have to be
+a period of time. For example, a distribution summary could be used to measure
+the payload sizes of requests hitting a server.
+
+It is recommended to always use base units when recording the data. So if
+measuring the payload size use bytes, not kilobytes or some other unit.
+
+Distribution summaries are created using the registry which will be setup as
+part of application initialization. For example:
+
+```java
+public class Server {
+
+  private final DistributionSummary requestSize;
+
+  @Inject
+  public Server(Registry registry) {
+    requestSize = registry.distributionSummary("server.requestSize");
+  }
+```
+
+Then call record when an event occurs:
+
+```java
+  public Response handle(Request request) {
+    requestSize.record(request.sizeInBytes());
+  }
+}
+```

--- a/src/main/paradox/spectator/gauges.md
+++ b/src/main/paradox/spectator/gauges.md
@@ -1,0 +1,193 @@
+# Gauges
+
+A gauge is a value that is sampled at some point in time. Typical examples
+for gauges would be the size of a queue or number of threads in the running
+state. Since gauges are not updated inline when a state change occurs, there is
+no information about what might have occurred between samples.
+
+Consider monitoring the behavior of a queue of tasks. If the data is being
+collected once a minute, then a gauge for the size will show the size when
+it was sampled. The size may have been much higher or lower at some point
+during interval, but that is not known.
+
+## Polled Gauges
+
+The most common use of gauges is by registering a hook with Spectator so that
+it will poll the values in the background. This is done by using the [PolledMeter]
+helper class.
+
+[PolledMeter]: http://netflix.github.io/spectator/en/latest/javadoc/spectator-api/com/netflix/spectator/api/patterns/PolledMeter.html
+
+A polled gauge is registered by passing in an id, a reference to the object, and
+a function to get or compute a numeric value based on the object. Note that
+a gauge should only be registered once, not on each update. Consider this
+example of a web server tracking the number of connections:
+
+```java
+class HttpServer {
+  // Tracks the number of current connections to the server
+  private AtomicInteger numConnections;
+
+  public HttpServer(Registry registry) {
+    numConnections = PolledMeter.using(registry)
+      .withName("server.numConnections")
+      .monitorValue(new AtomicInteger(0));
+  }
+
+  public void onConnectionCreated() {
+    numConnections.incrementAndGet();
+    ...
+  }
+
+  public void onConnectionClosed() {
+    numConnections.decrementAndGet();
+    ...
+  }
+
+  ...
+}
+```
+
+The spectator registry will keep a weak reference to the object. If the object is
+garbage collected, then it will automatically drop the registration. In the example
+above, the registry will have a weak reference to `numConnections` and the server
+instance will have a strong reference to `numConnections`. If the server instance
+goes away, then the gauge will as well.
+
+When multiple gauges are registered with the same id the reported value will
+be the sum of the matches. For example, if multiple instances of the `HttpServer`
+class were created on different ports, then the value `server.numConnections`
+would be the total number of connections across all server instances. If a different
+behavior is desired, then ensure your usage does not perform multiple registrations.
+
+There are several different ways to register a gauge:
+
+### Using Number
+
+A gauge can also be created based on an implementation of Number. Note the number
+implementation should be thread safe. For example:
+
+```java
+AtomicInteger size = new AtomicInteger();
+PolledMeter.using(registry)
+  .withName("queue.size")
+  .monitorValue(size);
+```
+
+The call will return the Number so the registration can be inline on the
+assignment:
+
+```java
+AtomicInteger size = PolledMeter.using(registry)
+  .withName("queue.size")
+  .monitorValue(size);
+```
+
+Updates to the value are preformed by updating the number instance directly.
+
+### Using Lambda
+
+Specify a lambda that takes the object as parameter.
+
+```java
+public class Queue {
+
+  @Inject
+  public Queue(Registry registry) {
+    PolledMeter.using(registry)
+      .withName("queue.size")
+      .monitorValue(this, Queue::size);
+  }
+
+  ...
+}
+```
+
+!!! warning
+    Be careful to avoid creating a reference to the object in the
+    lambda. It will prevent garbage collection and can lead to a memory leak
+    in the application. For example, by calling size without using the passed
+    in object there will be a reference to `this`:
+
+    ```
+    PolledMeter.using(registry).withName("queue.size").monitorValue(this, obj -> size());
+    ```
+
+### Collection Sizes
+
+For classes that implement `Collection` or `Map` there are helpers:
+
+```java
+Queue queue = new LinkedBlockingQueue();
+PolledMeter.using(registry)
+  .withName("queue.size")
+  .monitorSize(queue);
+
+Map<String, String> cache = new ConcurrentMap<>();
+PolledMeter.using(registry)
+  .withName("cache.size")
+  .monitorSize(cache);
+```
+
+### Monotonic Counters
+
+A common technique used by some libraries is to expose a monotonically increasing
+counter that represents the number of events since the system was initialized. An
+example of that in the JDK is [ThreadPoolExecutor.getCompletedTaskCount()] which
+returns the number of completed tasks on the thread pool.
+
+For sources like this the `monitorMonotonicCounter` method can be used:
+
+```java
+// For an implementation of Number
+LongAdder tasks = new LongAdder();
+PolledMeter.using(registry)
+  .withName("pool.completedTasks")
+  .monitorMonotonicCounter(tasks);
+
+// Or using a lambda
+ThreadPoolExecutor executor = ...
+PolledMeter.using(registry)
+  .withName("pool.completedTasks")
+  .monitorMonotonicCounter(executor, ThreadPoolExecutor::getCompletedTaskCount);
+```
+
+For thread pools specifically, there are better options for getting standard metrics.
+See the docs for the [Thread Pools extension](../ext/thread-pools.md) for more
+information.
+
+[ThreadPoolExecutor.getCompletedTaskCount()]: https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ThreadPoolExecutor.html#getCompletedTaskCount--
+
+## Active Gauges
+
+Gauges can also be set directly by the user. In this mode the user is responsible for
+regularly updating the value of the gauge by calling set. Looking at the HttpServer
+example, with an active gauge it would look like:
+
+```java
+class HttpServer {
+  // Tracks the number of current connections to the server
+  private AtomicInteger numConnections;
+  private Gauge gauge;
+
+  public HttpServer(Registry registry) {
+    numConnections = new AtomicInteger();
+    gauge = registry.gauge("server.numConnections");
+    gauge.set(numConnections.get());
+  }
+
+  public void onConnectionCreated() {
+    numConnections.incrementAndGet();
+    gauge.set(numConnections.get());
+    ...
+  }
+
+  public void onConnectionClosed() {
+    numConnections.decrementAndGet();
+    gauge.set(numConnections.get());
+    ...
+  }
+
+  ...
+}
+```

--- a/src/main/paradox/spectator/index.md
+++ b/src/main/paradox/spectator/index.md
@@ -1,11 +1,31 @@
 @@@ index
 
+* [Registry](registry.md)
+* [Counters](counters.md)
 * [Timers](timers.md)
+* [Distribution Summaries](dist-summaries.md)
+* [Gauges](gauges.md)
+* [Clock](clock.md)
+* [Testing](testing.md)
 * [Netflix Integration](netflix.md)
+* [Conventions](conventions.md)
+* [Servo](servo.md)
 
 @@@
 
 # Spectator
 
-Atlas client library.
+Simple library for instrumenting code to record dimensional time series. If
+you are new to the library it is highly recommended to read the pages in the
+*Getting Started* section on the sidebar.
+
+At a minimum you will need to:
+
+1. Depend on the api library. It is in maven central, for gradle the dependency
+   would be `com.netflix.spectator:spectator-api:0.62.0`.
+2. Instrument some code, see the usage guides for [counters](intro/counter.md),
+   [timers](intro/timer.md), and [gauges](intro/gauge.md).
+3. Pick a registry to bind to when initializing the application. See the sidebar
+   for a list of available registries.
+
 

--- a/src/main/paradox/spectator/registry.md
+++ b/src/main/paradox/spectator/registry.md
@@ -1,0 +1,197 @@
+# Registry
+
+There are a few basic concepts you need to learn to use Spectator.
+The [registry](http://netflix.github.io/spectator/en/latest/javadoc/spectator-api/com/netflix/spectator/api/Registry.html)
+is the main class for managing a set of meters. A meter is a class for collecting a set of
+measurements about your application.
+
+## Choosing an Implementation
+
+The core spectator library, `spectator-api`, comes with the following registry implementations:
+ 
+ <table>
+   <thead>
+     <th>Class</th>
+     <th>Dependency</th>
+     <th>Description</th>
+   </thead>
+   <tbody>
+     <tr>
+       <td>
+       [DefaultRegistry](http://netflix.github.io/spectator/en/latest/javadoc/spectator-api/com/netflix/spectator/api/DefaultRegistry.html)
+       </td>
+       <td>spectator-api</td>
+       <td>
+       Updates local counters, frequently used with [unit tests](testing.md).
+       </td>
+     </tr>
+     <tr>
+       <td>
+       [NoopRegistry](http://netflix.github.io/spectator/en/latest/javadoc/spectator-api/com/netflix/spectator/api/NoopRegistry.html)
+       </td>
+       <td>spectator-api</td>
+       <td>
+       Does nothing, tries to make operations as cheap as possible. This implementation is
+       typically used to help understand the overhead being created due to instrumentation.
+       It can also be useful in testing to help ensure that no side effects were introduced
+       where the instrumentation is now needed in order for the application for function
+       properly.
+       </td>
+     </tr>
+     <tr>
+       <td>
+       [ServoRegistry](http://netflix.github.io/spectator/en/latest/javadoc/spectator-reg-servo/com/netflix/spectator/servo/ServoRegistry.html)
+       </td>
+       <td>[spectator-reg-servo](../registry/servo.md)</td>
+       <td>
+       Map to [servo library](https://github.com/Netflix/servo). This is the implementation
+       typically used at Netflix to report data into [Atlas](https://github.com/Netflix/atlas).
+       </td>
+     </tr>
+     <tr>
+       <td>
+       [MetricsRegistry](http://netflix.github.io/spectator/en/latest/javadoc/spectator-reg-metrics3/com/netflix/spectator/metrics3/MetricsRegistry.html)
+       </td>
+       <td>[spectator-reg-metrics3](../registry/metrics3.md)</td>
+       <td>
+       Map to [metrics3 library](http://metrics.dropwizard.io/3.1.0/). This implementation
+       is typically used for reporting to local files, JMX, or other backends like Graphite.
+       Note that it uses a hierarchical naming scheme rather than the dimensional naming
+       used by Spectator, so the names will get flattened when mapped to this registry.
+       </td>
+     </tr>
+   </tbody>
+ </table>
+
+It is recommended for libraries to write code against the
+[Registry](http://netflix.github.io/spectator/en/latest/javadoc/spectator-api/com/netflix/spectator/api/Registry.html)
+interface and allow the implementation to get injected by the user of the library. The
+simplest way is to accept the registry via the constructor, for example:
+
+```java
+public class HttpServer {
+  public HttpServer(Registry registry) {
+    // use registry to collect measurements
+  }
+}
+```
+
+The user of the class can then provide the implementation:
+
+```java
+Registry registry = new DefaultRegistry();
+HttpServer server = new HttpServer(registry);
+```
+
+More complete examples can be found on the [testing page](testing.md) or in the
+[spectator-examples repo](https://github.com/brharrington/spectator-examples).
+
+## Working With Ids
+
+Spectator is primarily intended for collecting data for dimensional time series
+backends like [Atlas](https://github.com/Netflix/atlas). The ids used for looking
+up a meter in the registry consist of a name and set of tags. Ids will be consumed
+many times by users after the data has been reported so they should be chosen with
+some care and thought about how they will get used. See the [conventions page](conventions.md)
+for some general guidelines.
+
+Ids are created via the registry, for example:
+
+```java
+Id id = registry.createId("server.requestCount");
+```
+
+The ids are immutable so they can be freely passed around and used in a concurrent
+context. Tags can be added when an id is created:
+
+```java
+Id id = registry.createId("server.requestCount", "status", "2xx", "method", "GET");
+```
+
+Or by using `withTag` and `withTags` on an existing id:
+
+```java
+public class HttpServer {
+  private final Id baseId;
+
+  public HttpServer(Registry registry) {
+    baseId = registry.createId("server.requestCount");
+  }
+
+  private void handleRequestComplete(HttpRequest req, HttpResponse res) {
+    // Remember Id is immutable, withTags will return a copy with the
+    // the additional metadata
+    Id reqId = baseId.withTags(
+      "status", res.getStatus(),
+      "method", req.getMethod().name());
+    registry.counter(reqId).increment();
+  }
+
+  private void handleRequestError(HttpRequest req, Throwable t) {
+    // Can also be added individually using `withTag`. However, it is better
+    // for performance to batch modifications using `withTags`.
+    Id reqId = baseId
+      .withTag("error",  t.getClass().getSimpleName())
+      .withTag("method", req.getMethod().name());
+    registry.counter(reqId).increment();
+  }
+}
+```
+
+## Collecting Measurements
+
+Once you have an id, the registry can be used to get an instance of a meter to
+record a measurement. Meters can roughly be categorized in two groups:
+
+### Active
+
+Active meters are ones that are called directly when some event occurs. There are
+three basic types supported:
+
+* [Counters](counter.md): measures how often something is occuring. This will be
+  reported to backend systems as a rate per second. For example, number of requests
+  processed by web server.
+* [Timers](timer.md): measures how long something took. For example, latency of
+  requests processed by a web server.
+* [Distribution Summaries](dist-summary.md): measures the size of something. For
+  example, entity sizes for requests processed by a web server.
+
+### Passive
+
+Passive meters are ones where the registry just has a reference to get the value
+when needed. For example, the number of current connections on a web server or
+the number threads that are currently in use. These will be [gauges](gauge.md).
+
+## Global Registry
+
+There are some use-cases where injecting the registry is not possible or is too
+cumbersome. The main example from the core spectator libraries is the
+[log4j appender](../ext/log4j2.md). The global registry is useful there because
+logging is often initialized before any other systems and Spectator itself uses
+logging via the slf4j api which is quite likely being bound to log4j when that
+the appender is being used. By using the global registry the logging initialization
+can proceed before the spectator initialization in the application. Though any
+measurements taken before a registry instance has been added will be lost.
+
+The global registry is accessed using:
+
+```java
+Registry registry = Spectator.globalRegistry();
+```
+
+By default it will not record anything. For a specific registry instance you can
+choose to configure it to work with the global registry by calling `add`:
+
+```java
+public void init() {
+  Registry registry = // Choose an appropriate implementation
+  
+  // Add it to the global registry so it will receive
+  // any activity on the global registry
+  Spectator.globalRegistry().add(registry);
+}
+```
+
+Any measurements taken while no registries are added to the global instance will
+be lost. If multiple registries are added, all will recieve updates made to the global
+registry.

--- a/src/main/paradox/spectator/servo.md
+++ b/src/main/paradox/spectator/servo.md
@@ -1,0 +1,782 @@
+# Servo Comparison
+
+[Servo](https://github.com/Netflix/servo) is an alternative client monitoring
+library that is also developed by Netflix. Originally spectator was an
+experiment for a simpler API that wrapped servo. It was done as a separate
+project to avoid breaking backwards compatibility for servo.
+
+From a user perspective, both will be supported for a long time, but most
+of our efforts for future improvement will go to spectator. For new code it
+is recommended to use the spectator API. If running
+[at Netflix](Netflix Integration) the correct bindings will be in place
+for both servo and spectator.
+
+## Differences
+
+This section provides a quick summary of the differences.
+
+### Simpler API
+
+Servo gives the user a lot of control, but this makes it hard to use
+correctly. For example, to create a counter the user needs to understand
+the tradeoffs and choose between:
+
+* [BasicCounter](#basiccounter)
+* [DynamicCounter](#dynamiccounter)
+* [ContextualCounter](#contextualcounter)
+* [StepCounter](#stepcounter)
+
+Further each of these can impact how data is reported to observers. The
+spectator API focuses on the constructs a user needs to instrument the
+code. In spectator the user would always use the registry to create a
+[Counter](counter.md). The implementation details are left up to the
+registry.
+
+The [registration](#registration) is simpler as well to avoid common pitfalls
+when using servo like overwriting a registered object.
+
+### More Focused
+
+The goal of spectator is instrumenting code to send to a dimensional
+time-series system like [Atlas](https://github.com/Netflix/atlas/wiki).
+Servo has goals of staying compatible with a number of legacy libraries
+and naming formats, exposing data to JMX, etc. Examples of how this
+influences decisions:
+
+* No support for non-numeric data. Servo supported this for exposing to JMX.
+  Exposing the numeric data registered in spectator to JMX can be done
+  using a registry that supports it, but there is no goal to be a general
+  interface for exposing arbitrary data in JMX.
+* No support for customizeable time units when reporting timer data. Base
+  units should always be used for reporting and conversions can be performed
+  in the presentation layer if needed. It also avoids a lot of the confusion
+  around the timer unit for the data and issues like creating aggregates that
+  are meaningless because of mixed units.
+
+It is better to have a simple way to get correct and easy to reason about
+data to the backend than many options. If you want more knobs, then you can use
+Servo.
+
+### DI Friendly
+
+When servo was originally written dependency injection was not heavily used
+at Netflix. Further servo needed to stay compatible with a number of use-cases
+that were heavily static.
+
+While spectator does have a static registry that can be used, the recommended
+way is to create a registry and inject it either manually or via a framework
+into the classes that need it. This also makes it much easier to
+[test in isolation](testing).
+
+## Migration
+
+If you want to migrate from the servo API to the spectator API, then this
+section provides some guides on how servo constructs can be ported over. The
+sub-sections are the class names of monitor types supported by servo.
+
+For users at Netflix, note we are not actively pushing teams to migrate
+or do any additional work. Servo is still supported and if it works for your
+use-cases feel free to continue using it. 
+
+### Registration
+
+First read through the [servo docs on registration](https://github.com/Netflix/servo/wiki/Getting-Started#registration-of-metrics).
+In servo if you have a class like:
+
+```java
+public class Foo {
+
+  private AtomicInteger gauge;
+  private Counter counter;
+
+  public Foo(String id) {
+    gauge = new AtomicInteger();
+    counter = new BasicCounter(MonitorConfig.builder("counter").build());
+    Monitors.registerObject(id, this);
+  }
+
+  @Monitor(name = "gauge", type = DataSourceType.GAUGE)
+  private int gauge() {
+    return gauge.get();
+  }
+
+  public void doSomething() {
+    ...
+  }
+}
+```
+
+The state of the class is in the member variables of an instance of `Foo`.
+If multiple instances of class `Foo` are created with the same value for `id`,
+then the last one will overwrite the others for the registration. So the
+values getting reported will only be from the last instance registered. Also
+the registry has a reference to the instance of `Foo` so it will never go
+away.
+
+For counters and timers one way to get around this is to use
+[DynamicCounter](#dynamiccounter) and [DynamicTimer](#dynamictimer)
+respectively. Those classes will automatically handle the registration and
+expire if there is no activity. They also get used for cases where the set
+of dimensions is not known up front.
+
+Gauges need to sample the state of something so they need to have a reference
+to an object that contains the state. So the user would need to ensure that
+only a single copy was registered leading to patterns like:
+
+```java
+class Foo {
+
+  private static class FooStats {
+
+    private AtomicInteger gauge;
+    private Counter counter;
+
+    public FooStats(String id) {
+      gauge = new AtomicInteger();
+      counter = new BasicCounter(MonitorConfig.builder("counter").build());
+      Monitors.registerObject(id, this);
+    }
+
+    @Monitor(name = "gauge", type = DataSourceType.GAUGE)
+    private int gauge() {
+      return gauge.get();
+    }
+  }
+
+  private static ConcurrentHashMap<String, FooStats> STATS =
+    new ConcurrentHashMap<>();
+
+  private final FooStats stats;
+
+  public Foo(String id) {
+    stats = STATS.computeIfAbsent(id, (i) -> new FooStats(i));
+  }
+
+  public void doSomething() {
+    ...
+    stats.update();
+  }
+}
+```
+
+This ensures that there is a single copy for a given id. In spectator this
+example would look like: 
+
+```java
+public class Foo {
+
+  private AtomicInteger gauge;
+  private Counter counter;
+
+  public Foo(Registry registry, String id) {
+    Id gaugeId = registry.createId("gauge").withTag("id", id);
+    gauge = registry.gauge(gaugeId, new AtomicInteger());
+    counter = registry.counter("counter", "id", id);
+  }
+
+  public void doSomething() {
+    ...
+  }
+}
+```
+
+Everything using the same registry will get the same counter
+instance if the same id is used. For the gauge the registry will
+keep a weak reference and will sum the values if multiple instances are
+present. Since it is a weak reference, nothing will prevent an instance of
+`Foo` from getting garbage collected.
+
+### Annotations
+
+Annotations are not supported, use the appropriate meter type:
+
+| DataSourceType | Spectator Alternative       |
+|----------------|-----------------------------|
+| COUNTER        | [Counter Usage](counter.md) |
+| GAUGE          | [Gauge Usage](gauge.md)     |
+| INFORMATIONAL  | Not supported               |
+
+### BasicCounter
+
+See the general overview of [registration differences](#registration) and
+summary of [counter usage](counter.md).
+
+Servo:
+
+```java
+public class Foo {
+  private final Counter c =
+    new BasicCounter(MonitorConfig.builder("name").build());
+
+  public Foo(String id) {
+    Monitors.registerObject(id, this);
+  }
+
+  public void doSomething() {
+    c.increment();
+  }
+}
+```
+
+Spectator:
+
+```java
+public class Foo {
+  private final Counter c;
+
+  @Inject
+  public Foo(Registry registry, String id) {
+    c = registry.counter("name", "id", id);
+  }
+
+  public void doSomething() {
+    c.increment();
+  }
+}
+```
+
+### BasicGauge
+
+See the general overview of [registration differences](#registration) and
+summary of [gauge usage](gauge.md).
+
+Servo:
+
+```java
+public class Foo {
+  private final BasicGauge g = new BasicGauge(
+    MonitorConfig.builder("name").build(),
+    this::getCurrentValue);
+
+  public Foo(String id) {
+    Monitors.registerObject(id, this);
+  }
+}
+```
+
+Spectator:
+
+```java
+public class Foo {
+  @Inject
+  public Foo(Registry registry, String id) {
+    Id gaugeId = registry.createId("name").withTag("id", id);
+    registry.gauge(gaugeId, this, Foo::getCurrentValue);
+  }
+}
+```
+
+### BasicTimer
+
+See the general overview of [registration differences](#registration) and
+summary of [timer usage](timer.md). Note in spectator the reported unit
+for timers is always seconds and cannot be changed. Seconds is the base unit
+and other units should only be used as a presentation detail. Servo allows
+the unit to be customized and defaults to milliseconds.
+
+Servo:
+
+```java
+public class Foo {
+  private final Timer t = new BasicTimer(
+    MonitorConfig.builder("name").build(), TimeUnit.SECONDS);
+
+  public Foo(String id) {
+    Monitors.registerObject(id, this);
+  }
+
+  public void doSomething() {
+    Stopwatch s = t.start();
+    try {
+      ...
+    } finally {
+      s.stop();
+    }
+  }
+}
+```
+
+Spectator:
+
+```java
+public class Foo {
+  private final Timer t;
+
+  @Inject
+  public Foo(Registry registry, String id) {
+    t = registry.timer("name", "id", id);
+  }
+
+  public void doSomething() {
+    t.record(() -> {
+      ...
+    });
+  }
+}
+```
+
+### BasicDistributionSummary
+
+See the general overview of [registration differences](#registration) and
+summary of [distribution summary usage](dist-summary.md).
+
+Servo:
+
+```java
+public class Foo {
+  private final BasicDistributionSummary s = new BasicDistributionSummary(
+    MonitorConfig.builder("name").build());
+
+  public Foo(String id) {
+    Monitors.registerObject(id, this);
+  }
+
+  public void doSomething() {
+    ...
+    s.record(getValue());
+  }
+}
+```
+
+Spectator:
+
+```java
+public class Foo {
+  private final DistributionSummary s;
+
+  @Inject
+  public Foo(Registry registry, String id) {
+    s = registry.distributionSummary("name", "id", id);
+  }
+
+  public void doSomething() {
+    ...
+    s.record(getValue());
+  }
+}
+```
+
+### BasicInformational
+
+Not supported, see [overview of differences](#differences).
+
+### BasicStopwatch
+
+There isn't an explicit stopwatch class in spectator. Just use a timing
+call directly. 
+
+Servo:
+
+```java
+  public void doSomething() {
+    Stopwatch s = timer.start();
+    try {
+      ...
+    } finally {
+      s.stop();
+    }
+  }
+```
+
+Spectator:
+
+```java
+  public void doSomething() {
+    final long s = System.nanoTime();
+    try {
+      ...
+    } finally {
+      timer.record(System.nanoTime() - s, TimeUnit.NANOSECONDS);
+    }
+  }
+```
+
+### BucketTimer
+
+See the general overview of [registration differences](#registration) and
+summary of [sandbox documentation](Sandbox). Note in spectator BucketTimer is
+provided in the sandbox extension library and may change in future as we
+gain more experience using it.
+
+Servo:
+
+```java
+public class Foo {
+  private final Timer t = new BucketTimer(
+    MonitorConfig.builder("name").build(),
+    new BucketConfig.Builder()
+      .withTimeUnit(TimeUnit.MILLISECONDS)
+      .withBuckets(new long[] { 500, 2500, 5000, 10000 })
+      .build());
+
+  public Foo(String id) {
+    Monitors.registerObject(id, this);
+  }
+
+  public void doSomething() {
+    Stopwatch s = t.start();
+    try {
+      ...
+    } finally {
+      s.stop();
+    }
+  }
+}
+```
+
+Spectator:
+
+```java
+public class Foo {
+  private final Timer t;
+
+  @Inject
+  public Foo(Registry registry, String id) {
+    Id timerId = registry.createId("name", "id", id);
+    BucketFunction f = BucketFunctions.latency(10, TimeUnit.SECONDS);
+    t = BucketTimer.get(registry, timerId, f);
+  }
+
+  public void doSomething() {
+    t.record(() -> {
+      ...
+    });
+  }
+}
+```
+
+### ContextualCounter
+
+Not supported. A fixed tag list for the context is too rigid and this class
+was never used much at Netflix. Future work being looked at in
+[issue-180](https://github.com/Netflix/spectator/issues/180).
+
+### ContextualTimer
+
+Not supported. A fixed tag list for the context is too rigid and this class
+was never used much at Netflix. Future work being looked at in
+[issue-180](https://github.com/Netflix/spectator/issues/180).
+
+### DoubleGauge
+
+See the general overview of [registration differences](#registration) and
+summary of [gauge usage](gauge.md).
+
+Servo:
+
+```java
+public class Foo {
+  private final DoubleGauge g = new DoubleGauge(
+    MonitorConfig.builder("name").build());
+
+  public Foo(String id) {
+    Monitors.registerObject(id, this);
+  }
+}
+```
+
+Spectator:
+
+```java
+import com.google.common.util.concurrent.AtomicDouble;
+
+public class Foo {
+  private final AtomicDouble v;
+
+  @Inject
+  public Foo(Registry registry, String id) {
+    Id gaugeId = registry.createId("name").withTag("id", id);
+    v = registry.gauge(gaugeId, new AtomicDouble());
+  }
+}
+```
+
+### DurationTimer
+
+See the general overview of [registration differences](#registration) and
+summary of [timer usage](timer.md#longtasktimer).
+
+Servo:
+
+```java
+public class Foo {
+  private final DurationTimer t = new DurationTimer(
+    MonitorConfig.builder("name").build());
+
+  public Foo(String id) {
+    Monitors.registerObject(id, this);
+  }
+}
+```
+
+Spectator:
+
+```java
+public class Foo {
+  private final LongTaskTimer t;
+
+  @Inject
+  public Foo(Registry registry, String id) {
+    t = registry.longTaskTimer("name", "id", id);
+  }
+}
+```
+
+### DynamicCounter
+
+See the general overview of [registration differences](#registration) and
+summary of [counter usage](counter.md).
+
+Servo:
+
+```java
+public class Foo {
+
+  private final String id;
+
+  public Foo(String id) {
+    this.id = id;
+  }
+
+  public void doSomething(Context ctxt) {
+    DynamicCounter.increment("staticId", "id", id);
+    DynamicCounter.increment("dynamicId", "id", id, "foo", ctxt.getFoo());
+  }
+}
+```
+
+Spectator:
+
+```java
+public class Foo {
+  private final Registry registry;
+  private final String id;
+  private final Counter staticCounter;
+  private final Id dynamicId;
+
+  @Inject
+  public Foo(Registry registry, String id) {
+    this.registry = registry;
+    this.id = id;
+    staticCounter = registry.counter("staticId", "id", id);
+    dynamicId = registry.createId("dynamicId", "id", id);
+  }
+
+  public void doSomething(Context ctxt) {
+    // Keeping the reference to the counter avoids additional allocations
+    // to create the id object and the lookup cost
+    staticCounter.increment();
+
+    // If the id is dynamic it must be looked up
+    registry.counter("dynamicId", "id", id, "foo", ctxt.getFoo()).increment();
+
+    // This will update the same counter as the line above, but the base part
+    // of the id is precomputed to make it cheaper to construct the id.
+    registry.counter(dynamicId.withTag("foo", ctxt.getFoo())).increment();
+  }
+}
+```
+
+### DynamicTimer
+
+See the general overview of [registration differences](#registration) and
+summary of [timer usage](timer.md).
+
+Servo:
+
+```java
+public class Foo {
+
+  private final String id;
+  private final MonitorConfig staticId;
+
+  public Foo(String id) {
+    this.id = id;
+    staticId = MonitorConfig.builder("staticId").withTag("id", id).build();
+  }
+
+  public void doSomething(Context ctxt) {
+    final long d = ctxt.getDurationMillis();
+    DynamicTimer.record(staticId, TimeUnit.SECONDS, d, TimeUnit.MILLISECONDS);
+
+    MonitorConfig dynamicId = MonitorConfig.builder("dynamicId")
+      .withTag("id", id)
+      .withTag("foo", ctxt.getFoo())
+      .build();
+    DynamicTimer.record(dynamicId, TimeUnit.SECONDS, d, TimeUnit.MILLISECONDS);
+  }
+}
+```
+
+Spectator:
+
+```java
+public class Foo {
+  private final Registry registry;
+  private final String id;
+  private final Timer staticTimer;
+  private final Id dynamicId;
+
+  @Inject
+  public Foo(Registry registry, String id) {
+    this.registry = registry;
+    this.id = id;
+    staticTimer = registry.timer("staticId", "id", id);
+    dynamicId = registry.createId("dynamicId", "id", id);
+  }
+
+  public void doSomething(Context ctxt) {
+    final long d = ctxt.getDurationMillis();
+
+    // Keeping the reference to the timer avoids additional allocations
+    // to create the id object and the lookup cost
+    staticTimer.record(d, TimeUnit.MILLISECONDS);
+
+    // If the id is dynamic it must be looked up
+    registry.timer("dynamicId", "id", id, "foo", ctxt.getFoo())
+      .record(d, TimeUnit.MILLISECONDS);
+
+    // This will update the same timer as the line above, but the base part
+    // of the id is precomputed to make it cheaper to construct the id.
+    registry.timer(dynamicId.withTag("foo", ctxt.getFoo()))
+      .record(d, TimeUnit.MILLISECONDS);
+  }
+}
+```
+
+### LongGauge
+
+See the general overview of [registration differences](#registration) and
+summary of [gauge usage](gauge.md).
+
+Servo:
+
+```java
+public class Foo {
+  private final LongGauge g = new LongGauge(
+    MonitorConfig.builder("name").build());
+
+  public Foo(String id) {
+    Monitors.registerObject(id, this);
+  }
+}
+```
+
+Spectator:
+
+```java
+public class Foo {
+  private final AtomicLong v;
+
+  @Inject
+  public Foo(Registry registry, String id) {
+    Id gaugeId = registry.createId("name").withTag("id", id);
+    v = registry.gauge(gaugeId, new AtomicLong());
+  }
+}
+```
+
+### MonitorConfig
+
+See the documentation on [naming](conventions.md).
+
+Servo:
+
+```java
+MonitorConfig id = MonitorConfig.builder("name")
+  .withTag("country", "US")
+  .withTag("device",  "xbox")
+  .build();
+```
+
+Spectator:
+
+```java
+Id id = registry.createId("name")
+  .withTag("country", "US")
+  .withTag("device",  "xbox");
+
+// or
+
+Id id = registry.createId("name", "country", "US", "device", "xbox");
+```
+
+### MonitoredCache
+
+Not supported because spectator does not have a direct dependency on guava.
+If there is enough demand an extension can be created.
+
+### NumberGauge
+
+See the general overview of [registration differences](#registration) and
+summary of [gauge usage](gauge.md).
+
+Servo:
+
+```java
+public class Foo {
+  private final NumberGauge g = new NumberGauge(
+    MonitorConfig.builder("name").build(), new AtomicLong());
+
+  public Foo(String id) {
+    Monitors.registerObject(id, this);
+  }
+}
+```
+
+Spectator:
+
+```java
+public class Foo {
+  private final AtomicLong v;
+
+  @Inject
+  public Foo(Registry registry, String id) {
+    Id gaugeId = registry.createId("name").withTag("id", id);
+    v = registry.gauge(gaugeId, new AtomicLong());
+  }
+}
+```
+
+### StatsTimer
+
+Not supported, see [overview of differences](#differences).
+
+### StepCounter
+
+See the general overview of [registration differences](#registration) and
+summary of [counter usage](counter.md).
+
+Servo:
+
+```java
+public class Foo {
+  private final Counter c =
+    new StepCounter(MonitorConfig.builder("name").build());
+
+  public Foo(String id) {
+    Monitors.registerObject(id, this);
+  }
+
+  public void doSomething() {
+    c.increment();
+  }
+}
+```
+
+Spectator:
+
+```java
+public class Foo {
+  private final Counter c;
+
+  @Inject
+  public Foo(Registry registry, String id) {
+    c = registry.counter("name", "id", id);
+  }
+
+  public void doSomething() {
+    c.increment();
+  }
+}
+```

--- a/src/main/paradox/spectator/testing.md
+++ b/src/main/paradox/spectator/testing.md
@@ -1,0 +1,105 @@
+# Testing
+
+Testing should be relatively straightforward if you are using injection for the registry.
+Consider a sample class:
+
+```java
+public class Foo {
+
+  private final Counter counter;
+
+  @Inject
+  public Foo(Registry registry) {
+    counter = registry.counter("foo");
+  }
+
+  public void doSomething() {
+    counter.increment();
+  }
+}
+```
+
+Tests will typically want to use an isolated instance of the `DefaultRegistry`.
+
+## Simple Test
+
+A basic standalone test class would look something like:
+
+```java
+public class FooTest {
+
+  private Registry registry;
+  private Foo foo;
+
+  @Before
+  public void init() {
+    registry = new DefaultRegistry();
+    foo = new Foo(registry);
+  }
+
+  @Test
+  public void doSomething() {
+    foo.doSomething();
+    Assert.assertEquals(1, registry.counter("foo").count());
+  }
+}
+```
+
+## Guice Test
+
+If using guice, then the `TestModule` can be used:
+
+```java
+public class FooTest {
+
+  private Registry registry;
+  private Foo foo;
+
+  @Before
+  public void init() {
+    Injector injector = Guice.createInjector(new TestModule());
+    registry = injector.getInstance(Registry.class);
+    foo = injector.getInstance(Foo.class);
+  }
+
+  @Test
+  public void doSomething() {
+    foo.doSomething();
+    Assert.assertEquals(1, registry.counter("foo").count());
+  }
+}
+```
+
+## Exceptions
+
+By default, for most user errors Spectator will log a warning rather than throw an exception.
+The rationale is that users do not often think about instrumentation and logging code causing
+an exception and interrupting the control flow of a program. However, for test cases it is
+recommended to be more aggressive and learn about problems as early as possible. This can
+be done by setting a system property:
+
+```
+spectator.api.propagateWarnings=true
+```
+
+Consider an example:
+
+```java
+private static final Id RARE_EXCEPTION_ID = null;
+
+public void doSomethingImportant() {
+  try {
+    ... do work ...
+  } catch (RareException e) {
+    // There is a bug in the program, an Id is not allowed to be null. In production we do
+    // not want it to throw and interrupt the control flow. Instrumentation should gracefully
+    // degrade.
+    registry.counter(RARE_EXCEPTION_ID).increment();
+
+    // These statements are important to provide context for operating the system
+    // and to ensure the app continues to function properly.
+    LOGGER.error("important context for user", e);
+    properlyHandleException(e);
+  }
+}
+```


### PR DESCRIPTION
This is just a quick migration of the spectator mkdocs
pages into this repo. Still need to clean up the links
and structure.