### PR TITLE
limit max-width on images

### DIFF
--- a/src/main/paradox/_template/js/page.js
+++ b/src/main/paradox/_template/js/page.js
@@ -105,6 +105,15 @@ const initialize = function(pageBase) {
   });
 
   /*
+   * Image Widths
+   *
+   * Set the max-width on images to ensure they do not exceed the content div.
+   */
+  $('img').each(function() {
+    $(this).css('max-width', '100%');
+  });
+
+  /*
    * Code Snippets
    *
    * Rewrite code definition lists to divs with appropriate class.


### PR DESCRIPTION
This prevents them from exceeding the width of the content
div and overlapping the page ToC on the right.