### PR TITLE
add atlas-expr directive for adding links

### DIFF
--- a/project/GraphDirective.scala
+++ b/project/GraphDirective.scala
@@ -1,15 +1,12 @@
 
-import java.net.URI
 import java.util.Base64
 
 import akka.http.scaladsl.model.Uri
 import com.lightbend.paradox.markdown.ContainerBlockDirective
-import com.lightbend.paradox.markdown.Directive
 import com.lightbend.paradox.markdown.Writer
 import com.netflix.atlas.config.ConfigManager
 import com.netflix.atlas.core.db.StaticDatabase
 import com.netflix.atlas.core.util.PngImage
-import com.netflix.atlas.core.util.Strings
 import com.netflix.atlas.eval.graph.Grapher
 import com.typesafe.config.ConfigFactory
 import org.pegdown.Printer
@@ -39,40 +36,9 @@ case class GraphDirective(context: Writer.Context)
     val dataUri = s"data:image/png;base64,$encoded"
 
     if (node.attributes.booleanValue("show-expr", false)) {
-      printer.print(s"""<div>${formatQuery(uri.toString())}</div>""")
+      printer.print(s"""<div>${StacklangDirective.formatUri(basePath, uri.toString())}</div>""")
     }
     printer.print(s"""<div><image src="$dataUri" alt="$uri" width="$width" height="$height"/></div>""")
-  }
-
-  def formatQuery(line: String): String = {
-    val uri = URI.create(line)
-    val params = Strings.parseQueryString(uri.getQuery)
-    val pstr = params.toList.sortWith(_._1 < _._1).flatMap {
-      case (k, vs) =>
-        vs.map { v =>
-          if (k == "q") formatQueryExpr(v) else s"$k=$v"
-        }
-    }
-    s"<pre>\n${uri.getPath}?\n  ${pstr.mkString("\n  &")}\n</pre>\n"
-  }
-
-  private def mkLink(prg: List[Any], name: String): String = {
-    s"""<a href="${basePath}asl-reference/$name.html">:$name</a>"""
-  }
-
-  private def formatQueryExpr(q: String): String = {
-    val parts = q.split(",").toList
-    val buf = new StringBuilder
-    buf.append("q=\n    ")
-    parts.zipWithIndex.foreach {
-      case (p, i) =>
-        if (p.startsWith(":"))
-          buf.append(mkLink(parts.take(i), p.substring(1))).append(',').append("\n    ")
-        else
-          buf.append(p).append(',')
-    }
-    val s = buf.toString
-    s.substring(0, s.lastIndexOf(","))
   }
 }
 

--- a/project/StacklangDirective.scala
+++ b/project/StacklangDirective.scala
@@ -1,18 +1,77 @@
 
+import java.net.URI
+import java.util.regex.Pattern
+
 import com.lightbend.paradox.markdown.ContainerBlockDirective
 import com.lightbend.paradox.markdown.Directive
 import com.lightbend.paradox.markdown.Writer
+import com.netflix.atlas.core.util.Strings
 import org.pegdown.Printer
 import org.pegdown.ast.DirectiveNode
 import org.pegdown.ast.Visitor
 
-object StacklangDirective extends ContainerBlockDirective("asl") with (Writer.Context => Directive) {
-  def apply(context: Writer.Context): Directive = StacklangDirective
+case class StacklangDirective(context: Writer.Context)
+  extends ContainerBlockDirective("atlas-expr") {
+
+  private val basePath = "../" * context.location.depth
 
   def render(node: DirectiveNode, visitor: Visitor, printer: Printer): Unit = {
-    val classes = node.attributes.classesString
-    printer.print(s"""<pre class="$classes">""")
-    printer.print(node.contents.split(",").mkString(",\n").trim)
+    val formatted = StacklangDirective.addReferenceLinks(basePath, node.contents.trim)
+    printer.print(s"""<pre>""")
+    printer.print(formatted)
     printer.print("""</pre>""")
+  }
+}
+
+object StacklangDirective extends (Writer.Context => Directive) {
+
+  def apply(context: Writer.Context): Directive = new StacklangDirective(context)
+
+  /** Format an existing Atlas graph URI. */
+  def formatUri(basePath: String, uriStr: String): String = {
+    val uri = URI.create(uriStr)
+    val params = Strings.parseQueryString(uri.getQuery)
+    val pstr = params.toList.sortWith(_._1 < _._1).flatMap {
+      case (k, vs) =>
+        vs.map { v =>
+          if (k == "q") formatQueryExpr(basePath, v) else s"$k=$v"
+        }
+    }
+    s"<pre>\n${uri.getPath}?\n  ${pstr.mkString("\n  &")}\n</pre>\n"
+  }
+
+  private def mkLink(basePath: String, name: String): String = {
+    s"""<a href="${basePath}asl-reference/$name.html">:$name</a>"""
+  }
+
+  private def formatQueryExpr(basePath: String, q: String): String = {
+    val parts = q.split(",").toList
+    val buf = new StringBuilder
+    buf.append("q=\n    ")
+    parts.zipWithIndex.foreach {
+      case (p, i) =>
+        if (p.startsWith(":"))
+          buf.append(mkLink(basePath, p.substring(1))).append(',').append("\n    ")
+        else
+          buf.append(p).append(',')
+    }
+    val s = buf.toString
+    s.substring(0, s.lastIndexOf(","))
+  }
+
+  /**
+    * Simply add links back to the reference docs for an expr. This allows the user to
+    * hand format the expression however they like.
+    */
+  def addReferenceLinks(basePath: String, input: String): String = {
+    val matcher = Pattern.compile(":([^,\\s]+)").matcher(input)
+    val builder = new StringBuffer()
+    while (matcher.find()) {
+      val name = matcher.group(1)
+      val link = mkLink(basePath, name)
+      matcher.appendReplacement(builder, link)
+    }
+    matcher.appendTail(builder)
+    builder.toString
   }
 }

--- a/src/main/paradox/asl/des.md
+++ b/src/main/paradox/asl/des.md
@@ -3,3 +3,33 @@
 @@@ atlas-graph { show-expr=true }
 /api/v1/graph?q=name,sps,:eq
 @@@
+
+
+@@@ atlas-expr
+# Query to generate the input line
+nf.cluster,alerttest,:eq,
+name,requestsPerSecond,:eq,:and,
+:sum,
+
+# Create a copy on the stack
+:dup,
+
+# Apply a DES function to generate a prediction
+:des-fast,
+
+# Used to set a threshold. The prediction should
+# be roughly equal to the line, in this case the
+# threshold would be 85% of the prediction.
+0.85,:mul,
+
+# Create a boolean signal line that is 1
+# for datapoints where the actual value is
+# less than the prediction and 0 where it
+# is greater than or equal the prediction.
+# The 1 values are where the alert should
+# trigger.
+:lt,
+
+# Apply presentation details.
+:rot,$name,:legend,
+@@@


### PR DESCRIPTION
This directive can be used for linking back to the reference
pages from an expression the user formatted by hand.