### PR TITLE
less intrusive header links

### DIFF
--- a/src/main/paradox/_template/css/page.css
+++ b/src/main/paradox/_template/css/page.css
@@ -47,6 +47,10 @@
   padding-left: 15px;
 }
 
+h1 a, h2 a, h3 a, h4 a, h4 a, h6 a {
+  all: inherit;
+}
+
 a.anchor {
   display: block;
   position: relative;

--- a/src/main/paradox/_template/js/page.js
+++ b/src/main/paradox/_template/js/page.js
@@ -101,7 +101,10 @@ const initialize = function(pageBase) {
 
   $('h1, h2, h3, h4, h5, h6').each(function() {
     var href = $(this).find('a').attr('href');
-    $(this).append('  <a href="' + href + '" style="font-size: 0.7em;">&para;</a>');
+    var text = $(this).text();
+    $(this).html(
+      '<a name="' + href.substring(1) + '" href="' + href + '" class="anchor"></a>' +
+      '<a href="' + href + '">' + text + '</a>');
   });
 
   /*


### PR DESCRIPTION
Someone mentioned the header links added a lot of visual
clutter. This simplifies it to just make the header text
the link.