### PR TITLE
fix depth for operator links

### DIFF
--- a/project/GraphDirective.scala
+++ b/project/GraphDirective.scala
@@ -22,7 +22,7 @@ case class GraphDirective(context: Writer.Context)
   private val db = new StaticDatabase(config.getConfig("atlas.core.db"))
   private val grapher = Grapher(config)
 
-  private val basePath = "../" * context.location.depth
+  private val basePath = "../" * (context.location.depth - 1)
 
 
   def render(node: DirectiveNode, visitor: Visitor, printer: Printer): Unit = {

--- a/project/StacklangDirective.scala
+++ b/project/StacklangDirective.scala
@@ -13,7 +13,7 @@ import org.pegdown.ast.Visitor
 case class StacklangDirective(context: Writer.Context)
   extends ContainerBlockDirective("atlas-expr") {
 
-  private val basePath = "../" * context.location.depth
+  private val basePath = "../" * (context.location.depth - 1)
 
   def render(node: DirectiveNode, visitor: Visitor, printer: Printer): Unit = {
     val formatted = StacklangDirective.addReferenceLinks(basePath, node.contents.trim)

--- a/src/main/paradox/overview.md
+++ b/src/main/paradox/overview.md
@@ -154,7 +154,7 @@ http://atlas/api/v1/graph
 
 Adding some comments to the stack expression to explain a bit what is going on:
 
-```
+@@@ atlas-expr
 # Query to generate the input line
 nf.cluster,alerttest,:eq,
 name,requestsPerSecond,:eq,:and,
@@ -193,7 +193,7 @@ name,requestsPerSecond,:eq,:and,
 :rot,$name,:legend,
 :rot,prediction,:legend,
 :rot,:vspan,60,:alpha,alert+triggered,:legend
-```
+@@@
 
 See the [stack language](Stack Language) page for more information.
 


### PR DESCRIPTION
It would work locally before because it is on the root
path, but for github pages where it is one level deep
it was going too far and removing the project folder.