### PR TITLE
add directive to format examples

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,8 @@ lazy val root = (project in file("."))
     name := "Atlas Docs",
     paradoxDirectives ++= Seq(
       GraphDirective,
-      StacklangDirective
+      StacklangDirective,
+      ExampleDirective
     ),
     paradoxTheme := None,
     paradoxNavigationDepth := 3,

--- a/project/ExampleDirective.scala
+++ b/project/ExampleDirective.scala
@@ -1,0 +1,102 @@
+
+import java.util.Base64
+
+import akka.http.scaladsl.model.Uri
+import com.lightbend.paradox.markdown.ContainerBlockDirective
+import com.lightbend.paradox.markdown.Directive
+import com.lightbend.paradox.markdown.Writer
+import com.netflix.atlas.config.ConfigManager
+import com.netflix.atlas.core.db.StaticDatabase
+import com.netflix.atlas.core.util.PngImage
+import com.netflix.atlas.eval.graph.Grapher
+import com.typesafe.config.ConfigFactory
+import org.pegdown.Printer
+import org.pegdown.ast.DirectiveNode
+import org.pegdown.ast.Visitor
+
+case class ExampleDirective(context: Writer.Context)
+  extends ContainerBlockDirective("atlas-example") {
+
+  private val config = ConfigFactory.load(getClass.getClassLoader)
+  ConfigManager.set(config)
+
+  private val db = new StaticDatabase(config.getConfig("atlas.core.db"))
+  private val grapher = Grapher(config)
+
+  private val basePath = "../" * (context.location.depth - 1)
+
+  private def parseLine(line: String): (String, String) = {
+    val sep = line.indexOf(':')
+    if (sep == -1)
+      "-" -> line
+    else
+      line.substring(0, sep).trim -> line.substring(sep + 1).trim
+  }
+
+  def render(node: DirectiveNode, visitor: Visitor, printer: Printer): Unit = {
+    val columns = node.contents.trim
+      .split("\n")
+      .map(_.trim)
+      .filterNot(_.isEmpty)
+      .map(parseLine)
+      .toList
+
+    val n = columns.size
+    val contentWidth = 700 // with current style sheet the table with is 704
+    val imageWidth = contentWidth / n
+    val imageHeight = math.max(imageWidth / 2, 100)
+    val params = s"&layout=image&w=$imageWidth&h=$imageHeight"
+
+    val images = columns.map { c =>
+      val uri = Uri(c._2 + params)
+      val image = grapher.evalAndRender(uri, db)
+      // Show the user the input uri without the additional rendering restrictions
+      // injected for the docs
+      ExampleDirective.createImageInfo(Uri(c._2), image)
+    }
+
+    printer.print(s"""
+      <table>
+        <thead>
+          <tr>
+            ${columns.map(c => s"<th>${c._1}</th>").mkString}
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            ${images.map(i => s"<td>${i.exprHtml(basePath)}</td>").mkString}
+          </tr><tr>
+            ${images.map(i => s"<td>${i.imageHtml}</td>").mkString}
+          </tr>
+        </tbody>
+      </table>
+    """)
+  }
+}
+
+object ExampleDirective extends (Writer.Context => Directive) {
+
+  def apply(context: Writer.Context): Directive = new ExampleDirective(context)
+
+  def createImageInfo(uri: Uri, image: Grapher.Result): ImageInfo = {
+    val meta = PngImage(image.data)
+    val width = meta.data.getWidth
+    val height = meta.data.getHeight
+    val encoded = Base64.getEncoder.encodeToString(image.data)
+    val dataUri = s"data:image/png;base64,$encoded"
+
+    ImageInfo(uri, dataUri, width, height)
+  }
+
+  case class ImageInfo(uri: Uri, dataUri: String, width: Int, height: Int) {
+
+    def exprHtml(basePath: String): String = {
+      StacklangDirective.formatExpr(basePath, uri.query().getOrElse("q", ""))
+    }
+
+    def imageHtml: String = {
+      s"""<image src="$dataUri" alt="$uri" width="$width" height="$height"/>"""
+    }
+  }
+}
+

--- a/project/StacklangDirective.scala
+++ b/project/StacklangDirective.scala
@@ -38,6 +38,22 @@ object StacklangDirective extends (Writer.Context => Directive) {
     s"<pre>\n${uri.getPath}?\n  ${pstr.mkString("\n  &")}\n</pre>\n"
   }
 
+  /** Format an existing Atlas expression. */
+  def formatExpr(basePath: String, exprStr: String): String = {
+    val parts = exprStr.split(",").toList
+    val buf = new StringBuilder
+    parts.zipWithIndex.foreach {
+      case (p, i) =>
+        if (p.startsWith(":"))
+          buf.append(mkLink(basePath, p.substring(1))).append(',').append("\n")
+        else
+          buf.append(p).append(',')
+    }
+    val s = buf.toString
+    val formatted = s.substring(0, s.lastIndexOf(","))
+    s"<pre>\n$formatted\n</pre>"
+  }
+
   private def mkLink(basePath: String, name: String): String = {
     s"""<a href="${basePath}asl-reference/$name.html">:$name</a>"""
   }

--- a/src/main/paradox/asl-reference/des-fast.md
+++ b/src/main/paradox/asl-reference/des-fast.md
@@ -16,6 +16,7 @@ instead.
 
 ## Example
 
-@@@ atlas-graph { show-expr=true }
-/api/v1/graph?q=name,requestsPerSecond,:eq,:sum,:des-fast
+@@@ atlas-example
+Before: /api/v1/graph?q=name,requestsPerSecond,:eq,:sum
+ After: /api/v1/graph?q=name,requestsPerSecond,:eq,:sum,:des-fast
 @@@

--- a/src/main/paradox/asl-reference/des-slow.md
+++ b/src/main/paradox/asl-reference/des-slow.md
@@ -16,6 +16,7 @@ instead.
 
 ## Example
 
-@@@ atlas-graph { show-expr=true }
-/api/v1/graph?q=name,requestsPerSecond,:eq,:sum,:des-slow
+@@@ atlas-example
+Before: /api/v1/graph?q=name,requestsPerSecond,:eq,:sum
+ After: /api/v1/graph?q=name,requestsPerSecond,:eq,:sum,:des-slow
 @@@

--- a/src/main/paradox/asl-reference/des-slower.md
+++ b/src/main/paradox/asl-reference/des-slower.md
@@ -16,6 +16,7 @@ instead.
 
 ## Example
 
-@@@ atlas-graph { show-expr=true }
-/api/v1/graph?q=name,requestsPerSecond,:eq,:sum,:des-slower
+@@@ atlas-example
+Before: /api/v1/graph?q=name,requestsPerSecond,:eq,:sum
+ After: /api/v1/graph?q=name,requestsPerSecond,:eq,:sum,:des-slower
 @@@

--- a/src/main/paradox/asl-reference/des.md
+++ b/src/main/paradox/asl-reference/des.md
@@ -12,6 +12,7 @@
 
 ## Example
 
-@@@ atlas-graph { show-expr=true }
-/api/v1/graph?q=name,requestsPerSecond,:eq,:sum,:dup,input,:legend,:swap,5,0.1,0.5,:des,des,:legend
+@@@ atlas-example
+Before: /api/v1/graph?q=name,requestsPerSecond,:eq,:sum
+ After: /api/v1/graph?q=name,requestsPerSecond,:eq,:sum,5,0.1,0.5,:des
 @@@

--- a/src/main/paradox/asl-reference/dist-avg.md
+++ b/src/main/paradox/asl-reference/dist-avg.md
@@ -10,14 +10,9 @@
 Compute standard deviation for [timers](http://netflix.github.io/spectator/en/latest/intro/timer/)
 and [distribution summaries](http://netflix.github.io/spectator/en/latest/intro/dist-summary/).
 
-## Examples
+## Example
 
-### `name,playback.startLatency,:eq,:dist-stddev`
-
-<table>
-  <thead><th>Pos</th><th>Input</th><th>Output</th></thead><tbody><tr>
-    <td>0</td>
-    <td><img src="https://raw.githubusercontent.com/wiki/Netflix/atlas/stacklang/gen-images/38448178.png" alt="38448178.png" width="286px" height="233px"/></td>
-    <td><img src="https://raw.githubusercontent.com/wiki/Netflix/atlas/stacklang/gen-images/a941b80a.png" alt="a941b80a.png" width="286px" height="233px"/></td>
-  </tr></tbody>
-</table>
+@@@ atlas-example
+Before: /api/v1/graph?q=name,playback.startLatency,:eq
+ After: /api/v1/graph?q=name,playback.startLatency,:eq,:dist-avg
+@@@

--- a/src/main/paradox/asl-reference/sdes-fast.md
+++ b/src/main/paradox/asl-reference/sdes-fast.md
@@ -14,6 +14,7 @@ Helper for computing sliding DES using settings to quickly adjust to the input l
 
 ## Example
 
-@@@ atlas-graph { show-expr=true }
-/api/v1/graph?q=name,requestsPerSecond,:eq,:sum,:sdes-fast
+@@@ atlas-example
+Before: /api/v1/graph?q=name,requestsPerSecond,:eq,:sum
+ After: /api/v1/graph?q=name,requestsPerSecond,:eq,:sum,:sdes-fast
 @@@

--- a/src/main/paradox/asl-reference/sdes-slow.md
+++ b/src/main/paradox/asl-reference/sdes-slow.md
@@ -14,6 +14,7 @@ Helper for computing sliding DES using settings to quickly adjust to the input l
 
 ## Example
 
-@@@ atlas-graph { show-expr=true }
-/api/v1/graph?q=name,requestsPerSecond,:eq,:sum,:sdes-slow
+@@@ atlas-example
+Before: /api/v1/graph?q=name,requestsPerSecond,:eq,:sum
+ After: /api/v1/graph?q=name,requestsPerSecond,:eq,:sum,:sdes-slow
 @@@

--- a/src/main/paradox/asl-reference/sdes-slower.md
+++ b/src/main/paradox/asl-reference/sdes-slower.md
@@ -14,6 +14,7 @@ Helper for computing sliding DES using settings to quickly adjust to the input l
 
 ## Example
 
-@@@ atlas-graph { show-expr=true }
-/api/v1/graph?q=name,requestsPerSecond,:eq,:sum,:sdes-slower
+@@@ atlas-example
+Before: /api/v1/graph?q=name,requestsPerSecond,:eq,:sum
+ After: /api/v1/graph?q=name,requestsPerSecond,:eq,:sum,:sdes-slower
 @@@

--- a/src/main/paradox/asl/alerting.md
+++ b/src/main/paradox/asl/alerting.md
@@ -27,44 +27,11 @@ is done by using the [:rolling-count](stateful-rolling-count) operator to get a 
 how many times the input signal has been true withing a specified window and then applying a
 second threshold to the rolling count.
 
-<table>
-<tr>
-<td>Input</td>
-<td>Rolling count</td>
-<td>Dampened signal</td>
-</tr>
-<tr>
-<td><img src="/api/v1/graph?s=e-3h&e=2012-01-01T07:00&tz=UTC&l=0&h=100&w=210&layout=image&q=nf.app,alerttest,:eq,name,ssCpuUser,:eq,:and,:sum,80,:gt" /></td>
-<td><img src="/api/v1/graph?s=e-3h&e=2012-01-01T07:00&tz=UTC&l=0&h=100&w=210&layout=image&q=nf.app,alerttest,:eq,name,ssCpuUser,:eq,:and,:sum,80,:gt,5,:rolling-count" /></td>
-<td><img src="/api/v1/graph?s=e-3h&e=2012-01-01T07:00&tz=UTC&l=0&h=100&w=210&layout=image&q=nf.app,alerttest,:eq,name,ssCpuUser,:eq,:and,:sum,80,:gt,5,:rolling-count,4,:gt" /></td>
-</tr>
-<tr>
-<td><pre>
-nf.app,alerttest,<a href="https://github.com/Netflix/atlas/wiki/query-eq">:eq</a>,
-name,ssCpuUser,<a href="https://github.com/Netflix/atlas/wiki/query-eq">:eq</a>,
-<a href="https://github.com/Netflix/atlas/wiki/query-and">:and</a>,
-<a href="https://github.com/Netflix/atlas/wiki/data-sum">:sum</a>,
-80,<a href="https://github.com/Netflix/atlas/wiki/math-gt">:gt</a>
-</pre></td>
-<td><pre>
-nf.app,alerttest,<a href="https://github.com/Netflix/atlas/wiki/query-eq">:eq</a>,
-name,ssCpuUser,<a href="https://github.com/Netflix/atlas/wiki/query-eq">:eq</a>,
-<a href="https://github.com/Netflix/atlas/wiki/query-and">:and</a>,
-<a href="https://github.com/Netflix/atlas/wiki/data-sum">:sum</a>,
-80,<a href="https://github.com/Netflix/atlas/wiki/math-gt">:gt</a>,
-<b>5,<a href="https://github.com/Netflix/atlas/wiki/stateful-rolling‐count">:rolling-count</a></b>
-</pre></td>
-<td><pre>
-nf.app,alerttest,<a href="https://github.com/Netflix/atlas/wiki/query-eq">:eq</a>,
-name,ssCpuUser,<a href="https://github.com/Netflix/atlas/wiki/query-eq">:eq</a>,
-<a href="https://github.com/Netflix/atlas/wiki/query-and">:and</a>,
-<a href="https://github.com/Netflix/atlas/wiki/data-sum">:sum</a>,
-80,<a href="https://github.com/Netflix/atlas/wiki/math-gt">:gt</a>,
-5,<a href="https://github.com/Netflix/atlas/wiki/stateful-rolling‐count">:rolling-count</a>,
-<b>4,<a href="https://github.com/Netflix/atlas/wiki/math-gt">:gt</a></b>
-</pre></td>
-</tr>
-</table>
+@@@ atlas-example
+Input: /api/v1/graph?s=e-3h&e=2012-01-01T07:00&tz=UTC&l=0&q=nf.app,alerttest,:eq,name,ssCpuUser,:eq,:and,:sum,80,:gt
+Rolling-count: /api/v1/graph?s=e-3h&e=2012-01-01T07:00&tz=UTC&l=0&q=nf.app,alerttest,:eq,name,ssCpuUser,:eq,:and,:sum,80,:gt,5,:rolling-count
+Dampened signal: /api/v1/graph?s=e-3h&e=2012-01-01T07:00&tz=UTC&l=0&q=nf.app,alerttest,:eq,name,ssCpuUser,:eq,:and,:sum,80,:gt,5,:rolling-count,4,:gt
+@@@
 
 ## Visualization
 


### PR DESCRIPTION
This directive takes care of some of the tedious layout
and works around issues that the other custom directives
cannot be used within custom HTML blocks.