### PR TITLE
fix toc overlap of content on smaller screens

### DIFF
--- a/src/main/paradox/_template/css/page.css
+++ b/src/main/paradox/_template/css/page.css
@@ -8,6 +8,7 @@
 
 #content {
   z-index: 1000;
+  min-width: 768px;
   max-width: 768px;
 }
 

--- a/src/main/paradox/_template/page.st
+++ b/src/main/paradox/_template/page.st
@@ -64,11 +64,11 @@
 
     <div class="container-fluid">
       <div class="row flex-xl-nowrap justify-content-md-center">
-        <div class="col-12 col-md-3 col-xl-2" id="nav-left">
+        <div class="d-none d-lg-block col-lg-2 col-xl-2" id="nav-left">
           $page.groups$
           $page.navigation$
         </div>
-        <div class="col-12 col-md-9 col-xl-8 py-md-3 pl-md-5" id="content">
+        <div class="col-12 col-md-9 col-xl-8" id="content">
           $page.content$
 
           $if(page.next.html)$


### PR DESCRIPTION
Adjust the grid so that the left navigation does not start
to overlap content when moving to smaller screens. Testing
on chrome and firefox it seems to behave consistently now.