### PR TITLE
fix sample graphs on alerting exprs page

### DIFF
--- a/src/main/paradox/asl/alerting.md
+++ b/src/main/paradox/asl/alerting.md
@@ -9,12 +9,16 @@ with the stack language and the [alerting philosophy](Alerting-Philosophy)
 To start we need an input metric. For this example the input will be a sample metric showing
 high CPU usage for a period:
 
+@@@ atlas-graph { show-expr=true }
 /api/v1/graph?s=e-3h&e=2012-01-01T07:00&tz=UTC&l=0&h=100&q=nf.app,alerttest,:eq,name,ssCpuUser,:eq,:and,:sum
+@@@
 
 Lets say we want to trigger an alert when the CPU usage goes above 80%. To do that simply use the
 [:gt](math-gt) operator and append `80,:gt` to the query:
 
+@@@ atlas-graph { show-expr=true }
 /api/v1/graph?s=e-3h&e=2012-01-01T07:00&tz=UTC&l=0&h=100&q=nf.app,alerttest,:eq,name,ssCpuUser,:eq,:and,:sum,80,:gt
+@@@
 
 The result is a _signal line_ that is non-zero, typically 1, when in a triggering state and zero
 when everything is fine.
@@ -39,7 +43,9 @@ A signal line is useful to tell whether or not something is in a triggered state
 be difficult for a person to follow. Alert expressions can be visualized by showing the
 input, threshold, and triggering state on the same graph.
 
+@@@ atlas-graph { show-expr=true }
 /api/v1/graph?s=e-3h&e=2012-01-01T07:00&tz=UTC&l=0&h=100&q=nf.app,alerttest,:eq,name,ssCpuUser,:eq,:and,:sum,80,:2over,:gt,:vspan,40,:alpha,triggered,:legend,:rot,input,:legend,:rot,threshold,:legend,:rot
+@@@
 
 ## Summary
 


### PR DESCRIPTION
They were not setup to use the `atlas-graph` directive.