### PR TITLE
move operator pages to ref directory

### DIFF
--- a/docs/asl/ref/and.md
+++ b/docs/asl/ref/and.md
@@ -1,0 +1,21 @@
+
+There are two variants of the `:and` operator.
+
+## Choosing
+
+This first variant is used for choosing the set of time series to operate on. It is
+a binary operator that matches if both of the sub-queries match. Suppose you have
+three time series:
+
+* `name=http.requests, status=200, nf.app=server`
+* `name=sys.cpu, type=user, nf.app=foo`
+* `name=sys.cpu, type=user, nf.app=bar`
+
+The query `name,sys.cpu,:eq,nf.app,foo,:eq,:and` would match:
+
+* `name=sys.cpu, type=user, nf.app=foo`
+
+## Math
+
+Compute a new time series where each interval has the value `(a AND b)` where `a`
+and `b` are the corresponding intervals in the input time series.

--- a/docs/asl/ref/eq.md
+++ b/docs/asl/ref/eq.md
@@ -1,0 +1,13 @@
+
+Query expression that matches time series where the value for a given key is an exact
+match for the provided value. Suppose you have three time series:
+
+* `name=http.requests, status=200, nf.app=server`
+* `name=http.requests, status=400, nf.app=server`
+* `name=sys.cpu, type=user, nf.app=server`
+
+The query `name,http.requests,:eq` would be equivalent to an infix query like
+`name = http.requests` and would match:
+
+* `name=http.requests, status=200, nf.app=server`
+* `name=http.requests, status=400, nf.app=server`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,7 +17,10 @@ nav:
   - Alerting Expressions: asl/alerting-expressions.md
   - Reference:
     - Choosing:
-      - eq: asl/eq.md
+      - and: asl/ref/and.md
+      - eq: asl/ref/eq.md
+    - Math:
+      - and: asl/ref/and.md
 - Spectator:
   - Overview: spectator/index.md
   - Core Types:


### PR DESCRIPTION
Makes it easier to browse the docs as the number of operators
grows.