### PR TITLE
fix block query pattern

### DIFF
--- a/plugins/mkdocs-atlas-formatting-plugin/mkdocs_atlas_formatting_plugin/block.py
+++ b/plugins/mkdocs-atlas-formatting-plugin/mkdocs_atlas_formatting_plugin/block.py
@@ -22,7 +22,7 @@ class Block:
 
     example_pattern = re.compile('([^:]+): (.+)')
     options_pattern = re.compile('.+@@@ ([a-z\\-]+)(?:$| { (.+) })')
-    query_pattern = re.compile('.*q=(.+)')
+    query_pattern = re.compile('.*q=([^&]+)')
 
     def __init__(self, webserver: Optional[NoopWebserver] = None) -> None:
         self.webserver: AtlasWebServer = AtlasWebServer() if not webserver else webserver

--- a/plugins/mkdocs-atlas-formatting-plugin/test/resources.py
+++ b/plugins/mkdocs-atlas-formatting-plugin/test/resources.py
@@ -1,3 +1,4 @@
+from typing import List
 
 atlas_example_start_line: str = '<p>@@@ atlas-example'
 
@@ -12,6 +13,12 @@ atlas_stacklang_start_line: str = '<p>@@@ atlas-stacklang'
 atlas_stacklang_line: str = '/api/v1/graph?s=e-3h&e=2012-01-01T07:00&tz=UTC&l=0&h=100&q=nf.app,alerttest,:eq,name,ssCpuUser,:eq,:and,:sum'
 
 invalid_start_line: str = '<p>@@@ foo-block'
+
+block_query_patterns: List[str] = [
+    '/api/v1/graph?q=nf.app,alerttest,:eq,name,ssCpuUser,:eq,:and,:sum&s=e-3h&e=2012-01-01T07:00&tz=UTC&l=0&h=100',
+    '/api/v1/graph?s=e-3h&q=nf.app,alerttest,:eq,name,ssCpuUser,:eq,:and,:sum&e=2012-01-01T07:00&tz=UTC&l=0&h=100',
+    '/api/v1/graph?s=e-3h&e=2012-01-01T07:00&tz=UTC&l=0&h=100&q=nf.app,alerttest,:eq,name,ssCpuUser,:eq,:and,:sum'
+]
 
 graph_image_html_template: str = """\
 <html>

--- a/plugins/mkdocs-atlas-formatting-plugin/test/test_block.py
+++ b/plugins/mkdocs-atlas-formatting-plugin/test/test_block.py
@@ -17,6 +17,11 @@ class BlockTest(unittest.TestCase):
         self.assertEqual(False, block.is_started)
         self.assertEqual(None, block.input_lines)
 
+    def test_query_pattern(self):
+        for uri in block_query_patterns:
+            m = Block.query_pattern.match(uri)
+            self.assertEqual('nf.app,alerttest,:eq,name,ssCpuUser,:eq,:and,:sum', m.group(1))
+
     def test_mk_image_tag(self):
         block = Block(NoopWebserver())
         image_tag = block.mk_image_tag(atlas_graph_line)


### PR DESCRIPTION
the original version would grab more characters than intended, if the query
was not at the end of the atlas uri. this version terminates the group if an
ampersand character is encountered.