### PR TITLE
shutdown atlas standalone webserver after the build

### DIFF
--- a/plugins/mkdocs-atlas-formatting-plugin/mkdocs_atlas_formatting_plugin/plugin.py
+++ b/plugins/mkdocs-atlas-formatting-plugin/mkdocs_atlas_formatting_plugin/plugin.py
@@ -22,3 +22,8 @@ class AtlasFormattingPlugin(BasePlugin):
     def on_page_content(self, html: str, page: Page, config: Config, files: Files) -> str:
         parser = Parser(page.title, html)
         return parser.html
+
+    def on_post_build(self, config: Config) -> None:
+        if config['site_url'] == 'https://netflix.github.io/atlas-docs/':
+            logger.info('shutdown webserver')
+            self.webserver.shutdown()

--- a/plugins/mkdocs-atlas-formatting-plugin/setup.py
+++ b/plugins/mkdocs-atlas-formatting-plugin/setup.py
@@ -5,10 +5,10 @@ setup(
     version='1.0.0',
     author='Matthew Johnson',
     author_email='matthewj@netflix.com',
-    description='Does things.',
+    description='Format Atlas directives in Markdown source to produce images and expression blocks.',
     license='Apache License, Version 2.0',
     keywords='atlas docs',
-    url='https://github.com/Netflix/atlas-docs',
+    url='https://github.com/Netflix/atlas-docs/tree/master/plugins/mkdocs-atlas-formatting-plugin',
     python_requires='>=3.6',
     install_requires=[
         'pillow',


### PR DESCRIPTION
Since the port detection and fail-to-start exception was added, to assist with
correctness when developing locally with `mkdocs serve`, the Travis build has
been failing, because the `mkdocs build` step starts the webserver and does not
stop it. Thus, when the `mkdocs gh-deploy` step runs to deploy the site, it fails.

This change adds a check to the post_build event, so that if the `mkdocs build`
command is running, it will shutdown the webserver before proceeding.

Additional details have also been added to setup.py.