### PR TITLE
add atlas-link-checker cli tool

### DIFF
--- a/plugins/atlas-link-checker/README.md
+++ b/plugins/atlas-link-checker/README.md
@@ -1,0 +1,42 @@
+## Introduction
+
+Check HTML links for correctness in the MkDocs build output for Atlas Docs.
+
+```bash
+./setup-venv.sh
+source venv/bin/activate
+mkdocs build
+atlas-link-checker
+```
+
+The following categories are highlighted in the report output:
+
+* OLD SITE LINKS. Links which point to the previous documentation site.
+* BARE LINKS. Links that lack an http:// or https:// prefix.
+* BAD LINKS. Links which do not return 200 OK.
+
+Example output:
+
+```
+INFO    -  ==== Overview - Atlas Docs: site/spectator/lang/java/registry/overview/index.html ====
+WARNING -  BARE LINKS:
+WARNING -    <a href="../../testing">unit tests</a>
+WARNING -    <a href="../metrics3">spectator-reg-metrics3</a>
+WARNING -    <a href="../../testing/">testing page</a>
+WARNING -    <a href="../../../../core/naming/">conventions page</a>
+WARNING -    <a href="../../../../core/meters/counter/">Counters</a>
+WARNING -    <a href="../../../../core/meters/timer/">Timers</a>
+WARNING -    <a href="../../../../core/meters/dist-summary/">Distribution Summaries</a>
+WARNING -    <a href="../../../../core/meters/gauge/">Gauges</a>
+WARNING -    <a href="../../ext/log4j2/">log4j appender</a>
+ERROR   -  BAD LINKS:
+ERROR   -    <a href="https://static.javadoc.io/com.netflix.spectator/spectator-api/0.92.0/com/netflix/spectator/metrics3/MetricsRegistry.html">MetricsRegistry</a>
+```
+
+You can restrict the number of pages to be checked by specifying either a page title or a
+filename:
+
+```bash
+atlas-link-checker --title "Overview - Atlas Docs"
+atlas-link-checker --fname site/spectator/index.html
+```

--- a/plugins/atlas-link-checker/atlas_link_checker/config.py
+++ b/plugins/atlas-link-checker/atlas_link_checker/config.py
@@ -1,0 +1,17 @@
+# the short name of the plugin, as used by the logger
+PLUGIN_NAME = 'link_checker'
+
+# mkdocs site build output directory
+MKDOCS_SITE_DIRECTORY = 'site'
+
+# list of links to exclude from validation
+EXCLUDED_LINKS = [
+    'https://www.mkdocs.org',
+    'https://squidfunk.github.io/mkdocs-material/'
+]
+
+# the base url of the old documentation site
+OLD_SITE_PREFIX = 'https://github.com/Netflix/atlas/wiki'
+
+# the base url of the new documentation site
+NEW_SITE_PREFIX = 'https://netflix.github.io/atlas-docs/'

--- a/plugins/atlas-link-checker/atlas_link_checker/logconfig.py
+++ b/plugins/atlas-link-checker/atlas_link_checker/logconfig.py
@@ -1,0 +1,14 @@
+import logging
+
+from .config import PLUGIN_NAME
+
+
+def setup_logging(name: str, level: int = logging.INFO) -> logging:
+    logger = logging.getLogger(f'{PLUGIN_NAME}.{name}')
+    logger.setLevel(level)
+    stream = logging.StreamHandler()
+    formatter = logging.Formatter('%(levelname)-7s -  %(message)s ')
+    stream.setFormatter(formatter)
+    if not len(logger.handlers):
+        logger.addHandler(stream)
+    return logger

--- a/plugins/atlas-link-checker/atlas_link_checker/main.py
+++ b/plugins/atlas-link-checker/atlas_link_checker/main.py
@@ -1,0 +1,158 @@
+import argparse
+import os.path
+from collections import namedtuple
+from glob import glob
+from typing import List
+from argparse import Namespace
+import requests
+from bs4 import BeautifulSoup
+from bs4.element import Tag
+
+from .config import EXCLUDED_LINKS, MKDOCS_SITE_DIRECTORY, OLD_SITE_PREFIX
+from .logconfig import setup_logging
+
+logger = setup_logging(__name__)
+
+
+LinkStatus = namedtuple('LinkStatus', ['old_site_links', 'bare_links', 'bad_links'])
+
+
+def parse_args() -> Namespace:
+    parser = argparse.ArgumentParser('get discovery information')
+    parser.add_argument('--title', type=str, help=f'check links on matching page title')
+    parser.add_argument('--fname', type=str, help=f'check links on matching file name')
+    return parser.parse_args()
+
+
+def html_files() -> List[str]:
+    if not os.path.isdir('site'):
+        raise FileNotFoundError('mkdocs site directory not found')
+
+    files = glob(f'{MKDOCS_SITE_DIRECTORY}/**/*.html', recursive=True)
+    logger.info(f'found {len(files)} html files in mkdocs site directory')
+
+    return files
+
+
+def read_file(fname: str) -> str:
+    with open(fname) as f:
+        return f.read()
+
+
+def skip_link(link: Tag) -> bool:
+    if link['href'] in EXCLUDED_LINKS:
+        return True
+    elif 'class' not in link.attrs:
+        return False
+    elif 'headerlink' in link['class']:
+        return True
+    elif True in [True for c in link['class'] if c.startswith('md-')]:
+        return True
+    else:
+        return False
+
+
+def html_links(soup: BeautifulSoup) -> List[Tag]:
+    links: List[Tag] = []
+
+    for link in soup.find_all('a'):
+        if skip_link(link):
+            continue
+        links.append(link)
+
+    return links
+
+
+def old_site_link(link: Tag) -> bool:
+    if link['href'].startswith(OLD_SITE_PREFIX):
+        return True
+    else:
+        return False
+
+
+def bare_link(link: Tag) -> bool:
+    if link['href'].startswith('http://'):
+        return False
+    elif link['href'].startswith('https://'):
+        return False
+    else:
+        return True
+
+
+def bad_link(link: Tag) -> bool:
+    try:
+        r = requests.get(link['href'], allow_redirects=False)
+    except requests.exceptions.ConnectionError:
+        return True
+
+    if r.ok:
+        return False
+    else:
+        return True
+
+
+def check_links(soup: BeautifulSoup) -> LinkStatus:
+    links = html_links(soup)
+
+    old_site_links: List[Tag] = []
+    bare_links: List[Tag] = []
+    bad_links: List[Tag] = []
+
+    for link in links:
+        if old_site_link(link):
+            old_site_links.append(link)
+
+        if bare_link(link):
+            bare_links.append(link)
+        elif bad_link(link):
+            bad_links.append(link)
+
+    return LinkStatus(old_site_links, bare_links, bad_links)
+
+
+def link_report(args: Namespace, fname: str) -> None:
+    if args.fname and fname != args.fname:
+        return
+
+    html = read_file(fname)
+    soup = BeautifulSoup(html, 'html.parser')
+    title = soup.title.contents[0]
+
+    if args.title and title != args.title:
+        return
+
+    logger.info(f'==== {title}: {fname} ====')
+
+    link_status = check_links(soup)
+
+    if len(link_status.bare_links) > 0:
+        logger.warning('BARE LINKS:')
+
+        for link in link_status.bare_links:
+            logger.warning(f'  {link}')
+
+    if len(link_status.old_site_links) > 0:
+        logger.warning('OLD SITE LINKS:')
+
+        for link in link_status.old_site_links:
+            logger.error(f'  {link}')
+
+    if len(link_status.bad_links) > 0:
+        logger.error('BAD LINKS:')
+
+        for link in link_status.bad_links:
+            logger.error(f'  {link}')
+
+
+def main():
+    args = parse_args()
+
+    if args.fname or args.title:
+        logger.info(f'restricted to filename [{args.fname}] or title [{args.title}]')
+
+    for fname in html_files():
+        link_report(args, fname)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/atlas-link-checker/setup.py
+++ b/plugins/atlas-link-checker/setup.py
@@ -1,0 +1,23 @@
+from setuptools import find_packages, setup
+
+
+setup(
+    name='atlas_link_checker',
+    version='1.0.0',
+    author='Matthew Johnson',
+    author_email='matthewj@netflix.com',
+    description='Check HTML links for correctness in the MkDocs build output for Atlas Docs.',
+    license='Apache License, Version 2.0',
+    keywords='atlas link checker',
+    url='https://github.com/Netflix/atlas-docs/tree/master/plugins/link-checker',
+    python_requires='>=3.6',
+    install_requires=[
+        'beautifulsoup4'
+    ],
+    extras_require={},
+    packages=find_packages(),
+    include_package_data=True,
+    entry_points={
+        'console_scripts': ['atlas-link-checker = atlas_link_checker.main:main'],
+    },
+)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+beautifulsoup4==4.8.1
 certifi==2019.9.11
 chardet==3.0.4
 Click==7.0
@@ -18,6 +19,8 @@ pymdown-extensions==6.0
 PyYAML==5.1.1
 requests==2.22.0
 six==1.12.0
+soupsieve==1.9.4
 tornado==6.0.3
 urllib3==1.25.6
+-e plugins/atlas-link-checker
 -e plugins/mkdocs-atlas-formatting-plugin


### PR DESCRIPTION
As we build up the new Atlas Docs site, we want to be able to validate that the
links in the site are correct. However, we do not want this check to occur with
the site build process, because we do not want transient connectivity errors to
fail the build.

This CLI tool is intended to be run as a one-off after the site has been built,
so that you can verify the status of the links embedded within the pages.