### PR TITLE
update ASL reference for :and

### DIFF
--- a/docs/asl/alerting-expressions.md
+++ b/docs/asl/alerting-expressions.md
@@ -2,6 +2,13 @@ The stack language provides some basic techniques to convert an input line into 
 that can be used to trigger and visualize alert conditions. This section assumes a familiarity
 with the stack language and the [alerting philosophy](Alerting-Philosophy).
 
+## Signal Line
+
+A signal line is a time series that indicates whether or not a condition is true for a particular
+interval. They are modelled by having zero indicate false and non-zero, typically 1, indicating
+true. Alerting expressions map some input time series to a set of signal lines that indicate true
+when in a triggering state.
+
 ## Threshold Alerts
 
 To start we need an input metric. For this example the input will be a sample metric showing

--- a/docs/asl/ref/and.md
+++ b/docs/asl/ref/and.md
@@ -3,19 +3,114 @@ There are two variants of the `:and` operator.
 
 ## Choosing
 
-This first variant is used for choosing the set of time series to operate on. It is
-a binary operator that matches if both of the sub-queries match. Suppose you have
-three time series:
+<table>
+  <tbody>
+  <tr>
+    <td>
+      <strong>Input Stack:</strong>
+      <table>
+        <tbody>
+        <tr><td>q2: Query</td></tr>
+        <tr><td>q1: Query</td></tr>
+        </tbody>
+      </table>
+    </td><td style="vertical-align: middle;">
+      &#8680;
+    </td><td>
+      <strong>Output Stack:</strong>
+      <table>
+        <tbody>
+        <tr><td>(q1 AND q2): Query</td></tr>
+        <tr><td>&nbsp;</td></tr>
+        </tbody>
+      </table>
+    </td>
+  </tr>
+  </tbody>
+</table>
 
-* `name=http.requests, status=200, nf.app=server`
-* `name=sys.cpu, type=user, nf.app=foo`
-* `name=sys.cpu, type=user, nf.app=bar`
+This first variant is used for [choosing](../tutorial.md#choosing) the set of time series to
+operate on. It is a binary operator that matches if both of the sub-queries match. For example,
+consider the following query:
 
-The query `name,sys.cpu,:eq,nf.app,foo,:eq,:and` would match:
+@@@ atlas-stacklang { hilite=:and }
+/api/v1/graph?q=nf.app,alerttest,:eq,name,ssCpuUser,:eq,:and
+@@@
 
-* `name=sys.cpu, type=user, nf.app=foo`
+When matching against the sample data in the table below, the highlighted time series would be
+included in the result set:
+
+<table>
+  <thead>
+  <th>Name</th><th>nf.app</th><th>nf.node</th>
+  </thead>
+  <tbody>
+  <tr class="atlas-hilite">
+    <td><strong>ssCpuUser</strong></td>
+    <td><strong>alerttest</strong></td>
+    <td>i-0123</td>
+  </tr><tr>
+    <td>ssCpuSystem</td>
+    <td><strong>alerttest</strong></td>
+    <td>i-0123</td>
+  </tr><tr>
+    <td><strong>ssCpuUser</strong></td>
+    <td>nccp</td>
+    <td>i-0abc</td>
+  </tr><tr>
+    <td>ssCpuSystem</td>
+    <td>nccp</td>
+    <td>i-0abc</td>
+  </tr><tr>
+    <td>numRequests</td>
+    <td>nccp</td>
+    <td>i-0abc</td>
+  </tr><tr>
+    <td><strong>ssCpuUser</strong></td>
+    <td>api</td>
+    <td>i-0456</td>
+  </tr>
+  </tbody>
+</table>
 
 ## Math
 
+<table>
+  <tbody>
+  <tr>
+    <td>
+      <strong>Input Stack:</strong>
+      <table>
+        <tbody>
+        <tr><td>ts2: TimeSeriesExpr</td></tr>
+        <tr><td>ts1: TimeSeriesExpr</td></tr>
+        </tbody>
+      </table>
+    </td><td style="vertical-align: middle;">
+      &#8680;
+    </td><td>
+      <strong>Output Stack:</strong>
+      <table>
+        <tbody>
+        <tr><td>(ts1 AND ts2): TimeSeriesExpr</td></tr>
+        <tr><td>&nbsp;</td></tr>
+        </tbody>
+      </table>
+    </td>
+  </tr>
+  </tbody>
+</table>
+
 Compute a new time series where each interval has the value `(a AND b)` where `a`
-and `b` are the corresponding intervals in the input time series.
+and `b` are the corresponding intervals in the input time series. For example:
+
+| **Time** | **a** | **b** | **a AND b** |
+|----------|-------|-------|-------------|
+|  00:01   | 0.0   |  0.0  |  0.0        |
+|  00:01   | 0.0   |  1.0  |  0.0        |
+|  00:02   | 1.0   |  0.0  |  0.0        |
+|  00:03   | 1.0   |  1.0  |  1.0        |
+|  00:04   | 0.5   |  1.7  |  1.0        |
+
+The result will be a [signal time series](../alerting-expressions.md#signal-line) that will
+be `1.0` for all intervals where the corresponding values of `a` and `b` are both non-zero.

--- a/docs/asl/tutorial.md
+++ b/docs/asl/tutorial.md
@@ -1,0 +1,28 @@
+
+## Introduction
+
+### What is a Stack Language?
+
+### Atlas Stack Language
+
+## Basic Operators
+
+### Choosing
+
+### Aggregation
+
+### Math
+
+#### Unary Operators
+
+#### Binary Operators
+
+#### Stateful Operators
+
+#### Filtering Operators
+
+### Presentation
+
+### Stack Manipulation
+
+## Execution Modes


### PR DESCRIPTION
Replaces the old stack effect diagram with something that
should be more approachable for users new to stack based
languages.

Update the examples to follow the internal ASL course. The
outline for the ASL tutorial has been filled in to allow
cross-linking, but the content has not been moved over yet.