### PR TITLE
remove reference to auto-bind

### DIFF
--- a/docs/spectator/lang/java/usage.md
+++ b/docs/spectator/lang/java/usage.md
@@ -233,18 +233,3 @@ paved path.
 
 If using `base-server`, then you will get the Spectator and Atlas bindings automatically.
 
-### Auto Plugin
-
-!!! warning
-    **Deprecated**: Use of `AutoBindSingleton` is generally discouraged. It is recommended to
-    use one of the other methods.
-
-If you are only interested in getting the GC logging, then there is a library with an auto-bind
-singleton that can be used:
-
-```
-com.netflix.spectator:spectator-nflx:{{ spectator_api.java_latest }}
-```
-
-Assuming you are using karyon/base-server or Governator with `com.netflix` in the list of base
-packages, then the plugin should be automatically loaded.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -132,7 +132,7 @@ theme:
 
 extra:
   spectator_api:
-      java_latest: 0.92.0
+      java_latest: 0.101.0
 
 extra_css:
   - css/custom.css


### PR DESCRIPTION
This has been removed as of 0.101.0: Netflix/spectator#790.