### PR TITLE
honor hilite option for example directive

### DIFF
--- a/docs/asl/ref/and.md
+++ b/docs/asl/ref/and.md
@@ -76,3 +76,9 @@ and `b` are the corresponding intervals in the input time series. For example:
 
 The result will be a [signal time series](../alerting-expressions.md#signal-line) that will
 be `1.0` for all intervals where the corresponding values of `a` and `b` are both non-zero.
+Example:
+
+@@@ atlas-example { hilite=:and }
+Input: /api/v1/graph?w=200&h=125&no_legend=1&s=e-3h&e=2012-01-01T07:00&tz=UTC&l=0&q=minuteOfDay,:time,:dup,300,:gt,:swap,310,:lt
+Output: /api/v1/graph?w=200&h=125&no_legend=1&s=e-3h&e=2012-01-01T07:00&tz=UTC&l=0&q=minuteOfDay,:time,:dup,300,:gt,:swap,310,:lt,:and
+@@@

--- a/plugins/mkdocs-atlas-formatting-plugin/mkdocs_atlas_formatting_plugin/block.py
+++ b/plugins/mkdocs-atlas-formatting-plugin/mkdocs_atlas_formatting_plugin/block.py
@@ -181,7 +181,11 @@ class Block:
         for title, uri in self.input_lines:
             titles.append(title)
             graphs.append(self.mk_image_tag(uri))
-            exprs.append(f'<pre>{self.fmt_atlas_expr(uri)}</pre>')
+
+            expr = self.fmt_atlas_expr(uri)
+            if self.options and 'hilite' in self.options:
+                expr = self.hilite(expr, self.options['hilite'])
+            exprs.append(f'<pre>{expr}</pre>')
 
         self.output_lines = ['<table><tbody>']
         self.output_lines.append(self.mk_table_row(titles))


### PR DESCRIPTION
This option was being ignored for the expressions used
in example blocks. Added an example to the :and page
to test.