### PR TITLE
send stdout/stderr of Atlas server to devnull

### DIFF
--- a/plugins/mkdocs-atlas-formatting-plugin/mkdocs_atlas_formatting_plugin/atlaswebserver.py
+++ b/plugins/mkdocs-atlas-formatting-plugin/mkdocs_atlas_formatting_plugin/atlaswebserver.py
@@ -4,7 +4,7 @@ import time
 from base64 import b64encode
 from contextlib import closing
 from io import BytesIO
-from subprocess import Popen, PIPE
+from subprocess import Popen, DEVNULL
 from typing import Optional, Tuple
 
 import requests
@@ -85,7 +85,7 @@ class AtlasWebServer:
 
         logger.info(f'starting atlas webserver on port {port}')
 
-        self.proc = Popen(['java', '-jar', jar], stdout=PIPE, stderr=PIPE)
+        self.proc = Popen(['java', '-jar', jar], stdout=DEVNULL, stderr=DEVNULL)
 
         count = 0
 


### PR DESCRIPTION
Before it was set to PIPE, but nothing was reading the
data. When the buffer for the pipe would fill up the
Atlas server would hang because the threads were blocked
trying to write to the log.