### PR TITLE
add remaining operators for choosing category

### DIFF
--- a/docs/asl/ref/false.md
+++ b/docs/asl/ref/false.md
@@ -1,0 +1,6 @@
+@@@ atlas-signature
+-->
+Query
+@@@
+
+Query expression that will not match any input time series. See also [:true](./true.md).

--- a/docs/asl/ref/ge.md
+++ b/docs/asl/ref/ge.md
@@ -1,0 +1,90 @@
+
+Greater than or equal operator. There are two variants of the `:ge` operator.
+
+## Choosing
+
+@@@ atlas-signature
+v: String
+k: String
+-->
+(k >= v): Query
+@@@
+
+This first variant is used for [choosing](../tutorial.md#choosing) the set of time series to
+operate on. It selects time series that have a value for a key that is greater than or equal
+to a specified value. For example, consider the following query:
+
+@@@ atlas-stacklang { hilite=:ge }
+/api/v1/graph?q=name,ssCpuSystem,:ge
+@@@
+
+When matching against the sample data in the table below, the highlighted time series would be
+included in the result set:
+
+<table>
+  <thead>
+  <th>Name</th><th>nf.app</th><th>nf.node</th>
+  </thead>
+  <tbody>
+  <tr class="atlas-hilite">
+    <td><strong>ssCpuUser</strong></td>
+    <td>alerttest</td>
+    <td>i-0123</td>
+  </tr><tr class="atlas-hilite">
+    <td><strong>ssCpuSystem</strong></td>
+    <td>alerttest</td>
+    <td>i-0123</td>
+  </tr><tr class="atlas-hilite">
+    <td><strong>ssCpuUser</strong></td>
+    <td>nccp</td>
+    <td>i-0abc</td>
+  </tr><tr class="atlas-hilite">
+    <td><strong>ssCpuSystem</strong></td>
+    <td>nccp</td>
+    <td>i-0abc</td>
+  </tr><tr>
+    <td>numRequests</td>
+    <td>nccp</td>
+    <td>i-0abc</td>
+  </tr><tr class="atlas-hilite">
+    <td><strong>ssCpuUser</strong></td>
+    <td>api</td>
+    <td>i-0456</td>
+  </tr>
+  </tbody>
+</table>
+
+## Math
+
+@@@ atlas-signature
+ts2: TimeSeriesExpr
+ts1: TimeSeriesExpr
+-->
+(ts1 >= ts2): TimeSeriesExpr
+@@@
+
+Compute a new time series where each interval has the value `(a >= b)` where `a`
+and `b` are the corresponding intervals in the input time series. For example:
+
+| **Time** | **a** | **b** | **a >= b** |
+|----------|-------|-------|-------------|
+|  00:01   | 0.0   |  0.0  |  0.0        |
+|  00:01   | 0.0   |  1.0  |  0.0        |
+|  00:02   | 1.0   |  0.0  |  1.0        |
+|  00:03   | 1.0   |  1.0  |  1.0        |
+|  00:04   | 0.5   |  1.7  |  0.0        |
+
+The result will be a [signal time series](../alerting-expressions.md#signal-line) that will
+be `1.0` for intervals where the condition is true and `0.0` for intervals where it is false.
+
+!!! info
+    Note, the data points have floating point values. It is advisable to avoid relying on
+    an exact equality match.
+
+Example:
+
+@@@ atlas-example { hilite=:ge }
+Input: /api/v1/graph?w=200&h=125&no_legend=1&s=e-3h&e=2012-01-01T07:00&tz=UTC&l=0&q=minuteOfHour,:time,hourOfDay,:time
+Output: /api/v1/graph?w=200&h=125&no_legend=1&s=e-3h&e=2012-01-01T07:00&tz=UTC&l=0&q=minuteOfHour,:time,hourOfDay,:time,:ge
+@@@
+

--- a/docs/asl/ref/gt.md
+++ b/docs/asl/ref/gt.md
@@ -1,0 +1,86 @@
+
+Greater than operator. There are two variants of the `:gt` operator.
+
+## Choosing
+
+@@@ atlas-signature
+v: String
+k: String
+-->
+(k > v): Query
+@@@
+
+This first variant is used for [choosing](../tutorial.md#choosing) the set of time series to
+operate on. It selects time series that have a value for a key that is greater than
+a specified value. For example, consider the following query:
+
+@@@ atlas-stacklang { hilite=:gt }
+/api/v1/graph?q=name,ssCpuSystem,:gt
+@@@
+
+When matching against the sample data in the table below, the highlighted time series would be
+included in the result set:
+
+<table>
+  <thead>
+  <th>Name</th><th>nf.app</th><th>nf.node</th>
+  </thead>
+  <tbody>
+  <tr class="atlas-hilite">
+    <td><strong>ssCpuUser</strong></td>
+    <td>alerttest</td>
+    <td>i-0123</td>
+  </tr><tr>
+    <td>ssCpuSystem</td>
+    <td>alerttest</td>
+    <td>i-0123</td>
+  </tr><tr class="atlas-hilite">
+    <td><strong>ssCpuUser</strong></td>
+    <td>nccp</td>
+    <td>i-0abc</td>
+  </tr><tr>
+    <td>ssCpuSystem</td>
+    <td>nccp</td>
+    <td>i-0abc</td>
+  </tr><tr>
+    <td>numRequests</td>
+    <td>nccp</td>
+    <td>i-0abc</td>
+  </tr><tr class="atlas-hilite">
+    <td><strong>ssCpuUser</strong></td>
+    <td>api</td>
+    <td>i-0456</td>
+  </tr>
+  </tbody>
+</table>
+
+## Math
+
+@@@ atlas-signature
+ts2: TimeSeriesExpr
+ts1: TimeSeriesExpr
+-->
+(ts1 > ts2): TimeSeriesExpr
+@@@
+
+Compute a new time series where each interval has the value `(a > b)` where `a`
+and `b` are the corresponding intervals in the input time series. For example:
+
+| **Time** | **a** | **b** | **a > b** |
+|----------|-------|-------|-------------|
+|  00:01   | 0.0   |  0.0  |  0.0        |
+|  00:01   | 0.0   |  1.0  |  0.0        |
+|  00:02   | 1.0   |  0.0  |  1.0        |
+|  00:03   | 1.0   |  1.0  |  0.0        |
+|  00:04   | 0.5   |  1.7  |  0.0        |
+
+The result will be a [signal time series](../alerting-expressions.md#signal-line) that will
+be `1.0` for intervals where the condition is true and `0.0` for intervals where it is false.
+
+Example:
+
+@@@ atlas-example { hilite=:gt }
+Input: /api/v1/graph?w=200&h=125&no_legend=1&s=e-3h&e=2012-01-01T07:00&tz=UTC&l=0&q=minuteOfHour,:time,hourOfDay,:time
+Output: /api/v1/graph?w=200&h=125&no_legend=1&s=e-3h&e=2012-01-01T07:00&tz=UTC&l=0&q=minuteOfHour,:time,hourOfDay,:time,:gt
+@@@
+

--- a/docs/asl/ref/has.md
+++ b/docs/asl/ref/has.md
@@ -1,0 +1,48 @@
+@@@ atlas-signature
+k: String
+-->
+Query
+@@@
+
+Select time series that have a specified key. For example, consider the following
+query:
+
+@@@ atlas-stacklang { hilite=:eq }
+/api/v1/graph?q=nf.node,:has
+@@@
+
+When matching against the sample data in the table below, the highlighted time series would be
+included in the result set:
+
+<table>
+  <thead>
+  <th>Name</th><th>nf.app</th><th>nf.node</th>
+  </thead>
+  <tbody>
+  <tr class="atlas-hilite">
+    <td>ssCpuUser</td>
+    <td>alerttest</td>
+    <td>i-0123</td>
+  </tr><tr class="atlas-hilite">
+    <td>ssCpuSystem</td>
+    <td>alerttest</td>
+    <td>i-0123</td>
+  </tr><tr class="atlas-hilite">
+    <td>ssCpuUser</td>
+    <td>nccp</td>
+    <td>i-0abc</td>
+  </tr><tr class="atlas-hilite">
+    <td>ssCpuSystem</td>
+    <td>nccp</td>
+    <td>i-0abc</td>
+  </tr><tr>
+    <td>numRequests</td>
+    <td>nccp</td>
+    <td>&nbsp;</td>
+  </tr><tr class="atlas-hilite">
+    <td>ssCpuUser</td>
+    <td>api</td>
+    <td>i-0456</td>
+  </tr>
+  </tbody>
+</table>

--- a/docs/asl/ref/le.md
+++ b/docs/asl/ref/le.md
@@ -1,0 +1,86 @@
+
+Less than or equal operator. There are two variants of the `:le` operator.
+
+## Choosing
+
+@@@ atlas-signature
+v: String
+k: String
+-->
+(k <= v): Query
+@@@
+
+This first variant is used for [choosing](../tutorial.md#choosing) the set of time series to
+operate on. It selects time series that have a value for a key that is less than or equal
+to a specified value. For example, consider the following query:
+
+@@@ atlas-stacklang { hilite=:le }
+/api/v1/graph?q=name,ssCpuSystem,:le
+@@@
+
+When matching against the sample data in the table below, the highlighted time series would be
+included in the result set:
+
+<table>
+  <thead>
+  <th>Name</th><th>nf.app</th><th>nf.node</th>
+  </thead>
+  <tbody>
+  <tr>
+    <td>ssCpuUser</td>
+    <td>alerttest</td>
+    <td>i-0123</td>
+  </tr><tr class="atlas-hilite">
+    <td><strong>ssCpuSystem</strong></td>
+    <td>alerttest</td>
+    <td>i-0123</td>
+  </tr><tr>
+    <td>ssCpuUser</td>
+    <td>nccp</td>
+    <td>i-0abc</td>
+  </tr><tr class="atlas-hilite">
+    <td><strong>ssCpuSystem</strong></td>
+    <td>nccp</td>
+    <td>i-0abc</td>
+  </tr><tr class="atlas-hilite">
+    <td><strong>numRequests</strong></td>
+    <td>nccp</td>
+    <td>i-0abc</td>
+  </tr><tr>
+    <td>ssCpuUser</td>
+    <td>api</td>
+    <td>i-0456</td>
+  </tr>
+  </tbody>
+</table>
+
+## Math
+
+@@@ atlas-signature
+ts2: TimeSeriesExpr
+ts1: TimeSeriesExpr
+-->
+(ts1 <= ts2): TimeSeriesExpr
+@@@
+
+Compute a new time series where each interval has the value `(a <= b)` where `a`
+and `b` are the corresponding intervals in the input time series. For example:
+
+| **Time** | **a** | **b** | **a <= b** |
+|----------|-------|-------|-------------|
+|  00:01   | 0.0   |  0.0  |  1.0        |
+|  00:01   | 0.0   |  1.0  |  1.0        |
+|  00:02   | 1.0   |  0.0  |  0.0        |
+|  00:03   | 1.0   |  1.0  |  1.0        |
+|  00:04   | 0.5   |  1.7  |  1.0        |
+
+The result will be a [signal time series](../alerting-expressions.md#signal-line) that will
+be `1.0` for intervals where the condition is true and `0.0` for intervals where it is false.
+
+Example:
+
+@@@ atlas-example { hilite=:le }
+Input: /api/v1/graph?w=200&h=125&no_legend=1&s=e-3h&e=2012-01-01T07:00&tz=UTC&l=0&q=minuteOfHour,:time,hourOfDay,:time
+Output: /api/v1/graph?w=200&h=125&no_legend=1&s=e-3h&e=2012-01-01T07:00&tz=UTC&l=0&q=minuteOfHour,:time,hourOfDay,:time,:le
+@@@
+

--- a/docs/asl/ref/lt.md
+++ b/docs/asl/ref/lt.md
@@ -1,0 +1,86 @@
+
+Less than operator. There are two variants of the `:lt` operator.
+
+## Choosing
+
+@@@ atlas-signature
+v: String
+k: String
+-->
+(k < v): Query
+@@@
+
+This first variant is used for [choosing](../tutorial.md#choosing) the set of time series to
+operate on. It selects time series that have a value for a key that is less than
+a specified value. For example, consider the following query:
+
+@@@ atlas-stacklang { hilite=:lt }
+/api/v1/graph?q=name,ssCpuSystem,:lt
+@@@
+
+When matching against the sample data in the table below, the highlighted time series would be
+included in the result set:
+
+<table>
+  <thead>
+  <th>Name</th><th>nf.app</th><th>nf.node</th>
+  </thead>
+  <tbody>
+  <tr>
+    <td>ssCpuUser</td>
+    <td>alerttest</td>
+    <td>i-0123</td>
+  </tr><tr>
+    <td>ssCpuSystem</td>
+    <td>alerttest</td>
+    <td>i-0123</td>
+  </tr><tr>
+    <td>ssCpuUser</td>
+    <td>nccp</td>
+    <td>i-0abc</td>
+  </tr><tr>
+    <td>ssCpuSystem</td>
+    <td>nccp</td>
+    <td>i-0abc</td>
+  </tr><tr class="atlas-hilite">
+    <td><strong>numRequests</strong></td>
+    <td>nccp</td>
+    <td>i-0abc</td>
+  </tr><tr>
+    <td>ssCpuUser</td>
+    <td>api</td>
+    <td>i-0456</td>
+  </tr>
+  </tbody>
+</table>
+
+## Math
+
+@@@ atlas-signature
+ts2: TimeSeriesExpr
+ts1: TimeSeriesExpr
+-->
+(ts1 < ts2): TimeSeriesExpr
+@@@
+
+Compute a new time series where each interval has the value `(a < b)` where `a`
+and `b` are the corresponding intervals in the input time series. For example:
+
+| **Time** | **a** | **b** | **a < b** |
+|----------|-------|-------|-------------|
+|  00:01   | 0.0   |  0.0  |  0.0        |
+|  00:01   | 0.0   |  1.0  |  1.0        |
+|  00:02   | 1.0   |  0.0  |  0.0        |
+|  00:03   | 1.0   |  1.0  |  0.0        |
+|  00:04   | 0.5   |  1.7  |  1.0        |
+
+The result will be a [signal time series](../alerting-expressions.md#signal-line) that will
+be `1.0` for intervals where the condition is true and `0.0` for intervals where it is false.
+
+Example:
+
+@@@ atlas-example { hilite=:lt }
+Input: /api/v1/graph?w=200&h=125&no_legend=1&s=e-3h&e=2012-01-01T07:00&tz=UTC&l=0&q=minuteOfHour,:time,hourOfDay,:time
+Output: /api/v1/graph?w=200&h=125&no_legend=1&s=e-3h&e=2012-01-01T07:00&tz=UTC&l=0&q=minuteOfHour,:time,hourOfDay,:time,:lt
+@@@
+

--- a/docs/asl/ref/not.md
+++ b/docs/asl/ref/not.md
@@ -1,0 +1,48 @@
+@@@ atlas-signature
+q: Query
+-->
+(!q): Query
+@@@
+
+Select time series that have a specified key. For example, consider the following
+query:
+
+@@@ atlas-stacklang { hilite=:not }
+/api/v1/graph?q=nf.node,:has,:not
+@@@
+
+When matching against the sample data in the table below, the highlighted time series would be
+included in the result set:
+
+<table>
+  <thead>
+  <th>Name</th><th>nf.app</th><th>nf.node</th>
+  </thead>
+  <tbody>
+  <tr>
+    <td>ssCpuUser</td>
+    <td>alerttest</td>
+    <td>i-0123</td>
+  </tr><tr>
+    <td>ssCpuSystem</td>
+    <td>alerttest</td>
+    <td>i-0123</td>
+  </tr><tr>
+    <td>ssCpuUser</td>
+    <td>nccp</td>
+    <td>i-0abc</td>
+  </tr><tr>
+    <td>ssCpuSystem</td>
+    <td>nccp</td>
+    <td>i-0abc</td>
+  </tr><tr class="atlas-hilite">
+    <td>numRequests</td>
+    <td>nccp</td>
+    <td>&nbsp;</td>
+  </tr><tr>
+    <td>ssCpuUser</td>
+    <td>api</td>
+    <td>i-0456</td>
+  </tr>
+  </tbody>
+</table>

--- a/docs/asl/ref/or.md
+++ b/docs/asl/ref/or.md
@@ -1,0 +1,84 @@
+
+There are two variants of the `:or` operator.
+
+## Choosing
+
+@@@ atlas-signature
+q2: Query
+q1: Query
+-->
+(q1 OR q2): Query
+@@@
+
+This first variant is used for [choosing](../tutorial.md#choosing) the set of time series to
+operate on. It is a binary operator that matches if either of the sub-queries match. For example,
+consider the following query:
+
+@@@ atlas-stacklang { hilite=:or }
+/api/v1/graph?q=nf.app,alerttest,:eq,name,ssCpuUser,:eq,:or
+@@@
+
+When matching against the sample data in the table below, the highlighted time series would be
+included in the result set:
+
+<table>
+  <thead>
+  <th>Name</th><th>nf.app</th><th>nf.node</th>
+  </thead>
+  <tbody>
+  <tr class="atlas-hilite">
+    <td><strong>ssCpuUser</strong></td>
+    <td><strong>alerttest</strong></td>
+    <td>i-0123</td>
+  </tr><tr class="atlas-hilite">
+    <td>ssCpuSystem</td>
+    <td><strong>alerttest</strong></td>
+    <td>i-0123</td>
+  </tr><tr class="atlas-hilite">
+    <td><strong>ssCpuUser</strong></td>
+    <td>nccp</td>
+    <td>i-0abc</td>
+  </tr><tr>
+    <td>ssCpuSystem</td>
+    <td>nccp</td>
+    <td>i-0abc</td>
+  </tr><tr>
+    <td>numRequests</td>
+    <td>nccp</td>
+    <td>i-0abc</td>
+  </tr><tr class="atlas-hilite">
+    <td><strong>ssCpuUser</strong></td>
+    <td>api</td>
+    <td>i-0456</td>
+  </tr>
+  </tbody>
+</table>
+
+## Math
+
+@@@ atlas-signature
+ts2: TimeSeriesExpr
+ts1: TimeSeriesExpr
+-->
+(ts1 OR ts2): TimeSeriesExpr
+@@@
+
+Compute a new time series where each interval has the value `(a OR b)` where `a`
+and `b` are the corresponding intervals in the input time series. For example:
+
+| **Time** | **a** | **b** | **a OR b** |
+|----------|-------|-------|-------------|
+|  00:01   | 0.0   |  0.0  |  0.0        |
+|  00:01   | 0.0   |  1.0  |  1.0        |
+|  00:02   | 1.0   |  0.0  |  1.0        |
+|  00:03   | 1.0   |  1.0  |  1.0        |
+|  00:04   | 0.5   |  1.7  |  1.0        |
+
+The result will be a [signal time series](../alerting-expressions.md#signal-line) that will
+be `1.0` for all intervals where the corresponding values of `a` or `b` are non-zero.
+Example:
+
+@@@ atlas-example { hilite=:or }
+Input: /api/v1/graph?w=200&h=125&no_legend=1&s=e-3h&e=2012-01-01T07:00&tz=UTC&l=0&q=minuteOfDay,:time,:dup,300,:gt,:swap,290,:lt
+Output: /api/v1/graph?w=200&h=125&no_legend=1&s=e-3h&e=2012-01-01T07:00&tz=UTC&l=0&q=minuteOfDay,:time,:dup,300,:gt,:swap,290,:lt,:or
+@@@

--- a/docs/asl/ref/true.md
+++ b/docs/asl/ref/true.md
@@ -1,0 +1,6 @@
+@@@ atlas-signature
+-->
+Query
+@@@
+
+Query expression that will match any input time series. See also [:false](./false.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,7 @@ nav:
       - gt: asl/ref/gt.md
       - le: asl/ref/le.md
       - lt: asl/ref/lt.md
+      - or: asl/ref/or.md
 - Spectator:
   - Overview: spectator/index.md
   - Core Concepts:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,11 +19,24 @@ nav:
     - Choosing:
       - and: asl/ref/and.md
       - eq: asl/ref/eq.md
+      - 'false': asl/ref/false.md
+      - ge: asl/ref/ge.md
+      - gt: asl/ref/gt.md
+      - has: asl/ref/has.md
       - in: asl/ref/in.md
+      - le: asl/ref/le.md
+      - lt: asl/ref/lt.md
+      - not: asl/ref/not.md
+      - or: asl/ref/or.md
       - re: asl/ref/re.md
       - reic: asl/ref/reic.md
+      - 'true': asl/ref/true.md
     - Math:
       - and: asl/ref/and.md
+      - ge: asl/ref/ge.md
+      - gt: asl/ref/gt.md
+      - le: asl/ref/le.md
+      - lt: asl/ref/lt.md
 - Spectator:
   - Overview: spectator/index.md
   - Core Concepts:


### PR DESCRIPTION
This completes the choosing category. For operators that
have multiple variants, the other variant has also been
filled in.