### PR TITLE
add aggregation operators to reference

### DIFF
--- a/docs/asl/ref/by.md
+++ b/docs/asl/ref/by.md
@@ -1,0 +1,97 @@
+Group by operator. There are two variants of the `:by` operator.
+
+## Aggregation
+
+@@@ atlas-signature
+keys: List[String]
+Query
+-->
+DataExpr
+@@@
+
+Groups the matching time series by a set of keys and applies an aggregation to matches of the
+group.
+
+@@@ atlas-stacklang { hilite=:by }
+/api/v1/graph?q=name,ssCpu,:re,(,name,),:by
+@@@
+
+When matching against the sample data in the table below, the highlighted time series would be
+included in the aggregate result:
+
+<table>
+  <thead>
+  <th>Name</th><th>nf.app</th><th>nf.node</th><th>Data</th>
+  </thead>
+  <tbody>
+  <tr class="atlas-hilite">
+    <td><strong>ssCpu</strong>User</td>
+    <td>alerttest</td>
+    <td>i-0123</td>
+    <td>[1.0, 2.0, NaN]</td>
+  </tr><tr class="atlas-hilite">
+    <td><strong>ssCpu</strong>System</td>
+    <td>alerttest</td>
+    <td>i-0123</td>
+    <td>[3.0, 4.0, 5.0]</td>
+  </tr><tr class="atlas-hilite">
+    <td><strong>ssCpu</strong>User</td>
+    <td>nccp</td>
+    <td>i-0abc</td>
+    <td>[8.0, 7.0, 6.0]</td>
+  </tr><tr class="atlas-hilite">
+    <td><strong>ssCpu</strong>System</td>
+    <td>nccp</td>
+    <td>i-0abc</td>
+    <td>[6.0, 7.0, 8.0]</td>
+  </tr><tr>
+    <td>numRequests</td>
+    <td>nccp</td>
+    <td>i-0abc</td>
+    <td>[1.0, 2.0, 4.0]</td>
+  </tr><tr class="atlas-hilite">
+    <td><strong>ssCpu</strong>User</td>
+    <td>api</td>
+    <td>i-0456</td>
+    <td>[1.0, 2.0, 2.0]</td>
+  </tr>
+  </tbody>
+</table>
+
+The aggregation function will be applied independently for each group. In this example above
+there are two matching values for the group by key `name`. This leads to a final result of:
+
+<table>
+  <thead>
+  <th>Name</th><th>Data</th>
+  </thead>
+  <tbody>
+  <tr class="atlas-hilite">
+    <td><strong>ssCpuSystem</strong></td>
+    <td>[9.0, 11.0, 13.0]</td>
+  </tr><tr class="atlas-hilite">
+    <td><strong>ssCpuUser</strong></td>
+    <td>[10.0, 11.0, 8.0]</td>
+  </tr>
+  </tbody>
+</table>
+
+The `name` tag is included in the result set since it is used for the grouping.
+
+## Math
+
+@@@ atlas-signature
+keys: List[String]
+TimeSeriesExpr
+-->
+TimeSeriesExpr
+@@@
+
+Groups the time series from the input expression by a set of keys and applies an aggregation
+to matches of the group. The keys used for this grouping must be a subset of keys from the
+initial group by clause. Example:
+
+@@@ atlas-example { hilite=:by }
+Input: /api/v1/graph?w=200&h=125&no_legend=1&s=e-3h&e=2012-01-01T07:00&tz=UTC&l=0&q=name,sps,:eq,:sum,(,nf.cluster,nf.node,),:by
+Output: /api/v1/graph?w=200&h=125&no_legend=1&s=e-3h&e=2012-01-01T07:00&tz=UTC&l=0&q=name,sps,:eq,:sum,(,nf.cluster,nf.node,),:by,:count,(,nf.cluster,),:by
+@@@

--- a/docs/asl/ref/count.md
+++ b/docs/asl/ref/count.md
@@ -1,0 +1,92 @@
+Count aggregation operator. There are two variants of the `:count` operator.
+
+## Aggregation
+
+@@@ atlas-signature
+Query
+-->
+DataExpr
+@@@
+
+Compute the number of time series that match the query and have a value for a given interval.
+
+@@@ atlas-stacklang { hilite=:count }
+/api/v1/graph?q=name,ssCpuUser,:eq,:count
+@@@
+
+When matching against the sample data in the table below, the highlighted time series would be
+included in the aggregate result:
+
+<table>
+  <thead>
+  <th>Name</th><th>nf.app</th><th>nf.node</th><th>Data</th>
+  </thead>
+  <tbody>
+  <tr class="atlas-hilite">
+    <td><strong>ssCpuUser</strong></td>
+    <td>alerttest</td>
+    <td>i-0123</td>
+    <td>[1.0, 2.0, NaN]</td>
+  </tr><tr>
+    <td>ssCpuSystem</td>
+    <td>alerttest</td>
+    <td>i-0123</td>
+    <td>[3.0, 4.0, 5.0]</td>
+  </tr><tr class="atlas-hilite">
+    <td><strong>ssCpuUser</strong></td>
+    <td>nccp</td>
+    <td>i-0abc</td>
+    <td>[8.0, 7.0, 6.0]</td>
+  </tr><tr>
+    <td>ssCpuSystem</td>
+    <td>nccp</td>
+    <td>i-0abc</td>
+    <td>[6.0, 7.0, 8.0]</td>
+  </tr><tr>
+    <td>numRequests</td>
+    <td>nccp</td>
+    <td>i-0abc</td>
+    <td>[1.0, 2.0, 4.0]</td>
+  </tr><tr class="atlas-hilite">
+    <td><strong>ssCpuUser</strong></td>
+    <td>api</td>
+    <td>i-0456</td>
+    <td>[1.0, 2.0, 2.0]</td>
+  </tr>
+  </tbody>
+</table>
+
+The values from the corresponding intervals will be aggregated. For the first interval using
+the sample data above the values are `1.0`, `8.0`, and `1.0`. Each value other than `NaN`
+contributes one to the count. This leads to a final result of:
+
+<table>
+  <thead>
+  <th>Name</th><th>Data</th>
+  </thead>
+  <tbody>
+  <tr class="atlas-hilite">
+    <td><strong>ssCpuUser</strong></td>
+    <td>[3.0, 3.0, 2.0]</td>
+  </tr>
+  </tbody>
+</table>
+
+The only tags for the aggregated result are those that are matched exactly ([:eq](eq.md) clause)
+as part of the choosing criteria or are included in a [group by](by.md).
+
+## Math
+
+@@@ atlas-signature
+TimeSeriesExpr
+-->
+TimeSeriesExpr
+@@@
+
+Compute the number of time series from the input expression and have a value for a given interval.
+Example:
+
+@@@ atlas-example { hilite=:count }
+Input: /api/v1/graph?w=200&h=125&no_legend=1&s=e-3h&e=2012-01-01T07:00&tz=UTC&l=0&q=name,sps,:eq,(,nf.cluster,),:by
+Output: /api/v1/graph?w=200&h=125&no_legend=1&s=e-3h&e=2012-01-01T07:00&tz=UTC&l=0&q=name,sps,:eq,(,nf.cluster,),:by,:count
+@@@

--- a/docs/asl/ref/max.md
+++ b/docs/asl/ref/max.md
@@ -1,0 +1,93 @@
+Max aggregation operator. There are two variants of the `:max` operator.
+
+## Aggregation
+
+@@@ atlas-signature
+Query
+-->
+DataExpr
+@@@
+
+Select the maximum value for corresponding times across all matching time series.
+
+@@@ atlas-stacklang { hilite=:max }
+/api/v1/graph?q=name,ssCpuUser,:eq,:max
+@@@
+
+When matching against the sample data in the table below, the highlighted time series would be
+included in the aggregate result:
+
+<table>
+  <thead>
+  <th>Name</th><th>nf.app</th><th>nf.node</th><th>Data</th>
+  </thead>
+  <tbody>
+  <tr class="atlas-hilite">
+    <td><strong>ssCpuUser</strong></td>
+    <td>alerttest</td>
+    <td>i-0123</td>
+    <td>[1.0, 2.0, NaN]</td>
+  </tr><tr>
+    <td>ssCpuSystem</td>
+    <td>alerttest</td>
+    <td>i-0123</td>
+    <td>[3.0, 4.0, 5.0]</td>
+  </tr><tr class="atlas-hilite">
+    <td><strong>ssCpuUser</strong></td>
+    <td>nccp</td>
+    <td>i-0abc</td>
+    <td>[8.0, 7.0, 6.0]</td>
+  </tr><tr>
+    <td>ssCpuSystem</td>
+    <td>nccp</td>
+    <td>i-0abc</td>
+    <td>[6.0, 7.0, 8.0]</td>
+  </tr><tr>
+    <td>numRequests</td>
+    <td>nccp</td>
+    <td>i-0abc</td>
+    <td>[1.0, 2.0, 4.0]</td>
+  </tr><tr class="atlas-hilite">
+    <td><strong>ssCpuUser</strong></td>
+    <td>api</td>
+    <td>i-0456</td>
+    <td>[1.0, 2.0, 2.0]</td>
+  </tr>
+  </tbody>
+</table>
+
+The values from the corresponding intervals will be aggregated. For the first interval using
+the sample data above the values are `1.0`, `8.0`, and `1.0`. Each value other than `NaN`
+contributes one to the max. This leads to a final result of:
+
+<table>
+  <thead>
+  <th>Name</th><th>Data</th>
+  </thead>
+  <tbody>
+  <tr class="atlas-hilite">
+    <td><strong>ssCpuUser</strong></td>
+    <td>[8.0, 7.0, 6.0]</td>
+  </tr>
+  </tbody>
+</table>
+
+The only tags for the aggregated result are those that are matched exactly ([:eq](eq.md) clause)
+as part of the choosing criteria or are included in a [group by](by.md).
+
+## Math
+
+@@@ atlas-signature
+TimeSeriesExpr
+-->
+TimeSeriesExpr
+@@@
+
+Select the maximum value for corresponding times across the time series resulting from the
+input expression. This is typically used when there is a need to use some other aggregation
+for the grouping. Example:
+
+@@@ atlas-example { hilite=:max }
+Input: /api/v1/graph?w=200&h=125&no_legend=1&s=e-3h&e=2012-01-01T07:00&tz=UTC&l=0&q=name,sps,:eq,:sum,(,nf.cluster,),:by
+Output: /api/v1/graph?w=200&h=125&no_legend=1&s=e-3h&e=2012-01-01T07:00&tz=UTC&l=0&q=name,sps,:eq,:sum,(,nf.cluster,),:by,:max
+@@@

--- a/docs/asl/ref/min.md
+++ b/docs/asl/ref/min.md
@@ -1,0 +1,93 @@
+Min aggregation operator. There are two variants of the `:min` operator.
+
+## Aggregation
+
+@@@ atlas-signature
+Query
+-->
+DataExpr
+@@@
+
+Select the minimum value for corresponding times across all matching time series.
+
+@@@ atlas-stacklang { hilite=:min }
+/api/v1/graph?q=name,ssCpuUser,:eq,:min
+@@@
+
+When matching against the sample data in the table below, the highlighted time series would be
+included in the aggregate result:
+
+<table>
+  <thead>
+  <th>Name</th><th>nf.app</th><th>nf.node</th><th>Data</th>
+  </thead>
+  <tbody>
+  <tr class="atlas-hilite">
+    <td><strong>ssCpuUser</strong></td>
+    <td>alerttest</td>
+    <td>i-0123</td>
+    <td>[1.0, 2.0, NaN]</td>
+  </tr><tr>
+    <td>ssCpuSystem</td>
+    <td>alerttest</td>
+    <td>i-0123</td>
+    <td>[3.0, 4.0, 5.0]</td>
+  </tr><tr class="atlas-hilite">
+    <td><strong>ssCpuUser</strong></td>
+    <td>nccp</td>
+    <td>i-0abc</td>
+    <td>[8.0, 7.0, 6.0]</td>
+  </tr><tr>
+    <td>ssCpuSystem</td>
+    <td>nccp</td>
+    <td>i-0abc</td>
+    <td>[6.0, 7.0, 8.0]</td>
+  </tr><tr>
+    <td>numRequests</td>
+    <td>nccp</td>
+    <td>i-0abc</td>
+    <td>[1.0, 2.0, 4.0]</td>
+  </tr><tr class="atlas-hilite">
+    <td><strong>ssCpuUser</strong></td>
+    <td>api</td>
+    <td>i-0456</td>
+    <td>[1.0, 2.0, 2.0]</td>
+  </tr>
+  </tbody>
+</table>
+
+The values from the corresponding intervals will be aggregated. For the first interval using
+the sample data above the values are `1.0`, `8.0`, and `1.0`. Each value other than `NaN`
+contributes one to the max. This leads to a final result of:
+
+<table>
+  <thead>
+  <th>Name</th><th>Data</th>
+  </thead>
+  <tbody>
+  <tr class="atlas-hilite">
+    <td><strong>ssCpuUser</strong></td>
+    <td>[1.0, 2.0, 2.0]</td>
+  </tr>
+  </tbody>
+</table>
+
+The only tags for the aggregated result are those that are matched exactly ([:eq](eq.md) clause)
+as part of the choosing criteria or are included in a [group by](by.md).
+
+## Math
+
+@@@ atlas-signature
+TimeSeriesExpr
+-->
+TimeSeriesExpr
+@@@
+
+Select the minimum value for corresponding times across the time series resulting from the
+input expression. This is typically used when there is a need to use some other aggregation
+for the grouping. Example:
+
+@@@ atlas-example { hilite=:min }
+Input: /api/v1/graph?w=200&h=125&no_legend=1&s=e-3h&e=2012-01-01T07:00&tz=UTC&l=0&q=name,sps,:eq,:sum,(,nf.cluster,),:by
+Output: /api/v1/graph?w=200&h=125&no_legend=1&s=e-3h&e=2012-01-01T07:00&tz=UTC&l=0&q=name,sps,:eq,:sum,(,nf.cluster,),:by,:min
+@@@

--- a/docs/asl/ref/sum.md
+++ b/docs/asl/ref/sum.md
@@ -1,0 +1,99 @@
+Sum aggregation operator. There are two variants of the `:sum` operator.
+
+## Aggregation
+
+@@@ atlas-signature
+Query
+-->
+DataExpr
+@@@
+
+Compute the sum of all the time series that match the query. Sum is the default aggregate
+used if a query is specified with no explicit aggregate function. Example with implicit sum:
+
+@@@ atlas-stacklang { hilite=:sum }
+/api/v1/graph?q=name,ssCpuUser,:eq
+@@@
+
+Equivalent example with explicit sum:
+
+@@@ atlas-stacklang { hilite=:sum }
+/api/v1/graph?q=name,ssCpuUser,:eq,:sum
+@@@
+
+When matching against the sample data in the table below, the highlighted time series would be
+included in the aggregate result:
+
+<table>
+  <thead>
+  <th>Name</th><th>nf.app</th><th>nf.node</th><th>Data</th>
+  </thead>
+  <tbody>
+  <tr class="atlas-hilite">
+    <td><strong>ssCpuUser</strong></td>
+    <td>alerttest</td>
+    <td>i-0123</td>
+    <td>[1.0, 2.0, NaN]</td>
+  </tr><tr>
+    <td>ssCpuSystem</td>
+    <td>alerttest</td>
+    <td>i-0123</td>
+    <td>[3.0, 4.0, 5.0]</td>
+  </tr><tr class="atlas-hilite">
+    <td><strong>ssCpuUser</strong></td>
+    <td>nccp</td>
+    <td>i-0abc</td>
+    <td>[8.0, 7.0, 6.0]</td>
+  </tr><tr>
+    <td>ssCpuSystem</td>
+    <td>nccp</td>
+    <td>i-0abc</td>
+    <td>[6.0, 7.0, 8.0]</td>
+  </tr><tr>
+    <td>numRequests</td>
+    <td>nccp</td>
+    <td>i-0abc</td>
+    <td>[1.0, 2.0, 4.0]</td>
+  </tr><tr class="atlas-hilite">
+    <td><strong>ssCpuUser</strong></td>
+    <td>api</td>
+    <td>i-0456</td>
+    <td>[1.0, 2.0, 2.0]</td>
+  </tr>
+  </tbody>
+</table>
+
+The values from the corresponding intervals will be aggregated. For the first interval using
+the sample data above the values are `1.0`, `8.0`, and `1.0`. Each value other than `NaN`
+contributes one to the sum. This leads to a final result of:
+
+<table>
+  <thead>
+  <th>Name</th><th>Data</th>
+  </thead>
+  <tbody>
+  <tr class="atlas-hilite">
+    <td><strong>ssCpuUser</strong></td>
+    <td>[10.0, 11.0, 8.0]</td>
+  </tr>
+  </tbody>
+</table>
+
+The only tags for the aggregated result are those that are matched exactly ([:eq](eq.md) clause)
+as part of the choosing criteria or are included in a [group by](by.md).
+
+## Math
+
+@@@ atlas-signature
+TimeSeriesExpr
+-->
+TimeSeriesExpr
+@@@
+
+Compute the sum of all the time series from the input expression. This is typically used when
+there is a need to use some other aggregation for the grouping. Example:
+
+@@@ atlas-example { hilite=:sum }
+Input: /api/v1/graph?w=200&h=125&no_legend=1&s=e-3h&e=2012-01-01T07:00&tz=UTC&l=0&q=name,sps,:eq,:max,(,nf.cluster,),:by
+Output: /api/v1/graph?w=200&h=125&no_legend=1&s=e-3h&e=2012-01-01T07:00&tz=UTC&l=0&q=name,sps,:eq,:max,(,nf.cluster,),:by,:sum
+@@@

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,13 +31,24 @@ nav:
       - re: asl/ref/re.md
       - reic: asl/ref/reic.md
       - 'true': asl/ref/true.md
+    - Aggregation:
+      - by: asl/ref/by.md
+      - count: asl/ref/count.md
+      - max: asl/ref/max.md
+      - min: asl/ref/min.md
+      - sum: asl/ref/sum.md
     - Math:
       - and: asl/ref/and.md
+      - by: asl/ref/by.md
+      - count: asl/ref/count.md
       - ge: asl/ref/ge.md
       - gt: asl/ref/gt.md
       - le: asl/ref/le.md
       - lt: asl/ref/lt.md
+      - max: asl/ref/max.md
+      - min: asl/ref/min.md
       - or: asl/ref/or.md
+      - sum: asl/ref/sum.md
 - Spectator:
   - Overview: spectator/index.md
   - Core Concepts:


### PR DESCRIPTION
Add entries for all of the basic aggregation operations
to the ASL reference. Still pending are offset and cf
operators.