### PR TITLE
add docs for deprecated stat operators

### DIFF
--- a/docs/asl/ref/stat-avg-mf.md
+++ b/docs/asl/ref/stat-avg-mf.md
@@ -1,0 +1,15 @@
+!!! warning
+    **Deprecated:** use [:stat](stat.md) instead.
+
+@@@ atlas-signature
+TimeSeriesExpr
+-->
+TimeSeriesExpr
+@@@
+
+Equivalent to `avg,:stat`. Example of usage:
+
+@@@ atlas-example { hilite=:stat-avg-mf }
+Before: /api/v1/graph?w=200&h=125&no_legend=1&s=e-12h&e=2012-01-01T07:00&tz=UTC&l=0&q=name,sps,:eq,:sum
+After: /api/v1/graph?w=200&h=125&no_legend=1&s=e-12h&e=2012-01-01T07:00&tz=UTC&l=0&q=name,sps,:eq,:sum,:stat-avg-mf
+@@@

--- a/docs/asl/ref/stat-max-mf.md
+++ b/docs/asl/ref/stat-max-mf.md
@@ -1,0 +1,15 @@
+!!! warning
+    **Deprecated:** use [:stat](stat.md) instead.
+
+@@@ atlas-signature
+TimeSeriesExpr
+-->
+TimeSeriesExpr
+@@@
+
+Equivalent to `max,:stat`. Example of usage:
+
+@@@ atlas-example { hilite=:stat-max-mf }
+Before: /api/v1/graph?w=200&h=125&no_legend=1&s=e-12h&e=2012-01-01T07:00&tz=UTC&l=0&q=name,sps,:eq,:sum
+After: /api/v1/graph?w=200&h=125&no_legend=1&s=e-12h&e=2012-01-01T07:00&tz=UTC&l=0&q=name,sps,:eq,:sum,:stat-max-mf
+@@@

--- a/docs/asl/ref/stat-min-mf.md
+++ b/docs/asl/ref/stat-min-mf.md
@@ -1,0 +1,15 @@
+!!! warning
+    **Deprecated:** use [:stat](stat.md) instead.
+
+@@@ atlas-signature
+TimeSeriesExpr
+-->
+TimeSeriesExpr
+@@@
+
+Equivalent to `min,:stat`. Example of usage:
+
+@@@ atlas-example { hilite=:stat-min-mf }
+Before: /api/v1/graph?w=200&h=125&no_legend=1&s=e-12h&e=2012-01-01T07:00&tz=UTC&l=0&q=name,sps,:eq,:sum
+After: /api/v1/graph?w=200&h=125&no_legend=1&s=e-12h&e=2012-01-01T07:00&tz=UTC&l=0&q=name,sps,:eq,:sum,:stat-min-mf
+@@@

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,10 @@ nav:
       - topk-others-min: asl/ref/topk-others-min.md
       - topk-others-sum: asl/ref/topk-others-sum.md
       - sum: asl/ref/sum.md
+    - Deprecated:
+      - stat-avg-mf: asl/ref/stat-avg-mf.md
+      - stat-max-mf: asl/ref/stat-max-mf.md
+      - stat-min-mf: asl/ref/stat-min-mf.md
 - Spectator:
   - Overview: spectator/index.md
   - Core Concepts:


### PR DESCRIPTION
Keep them in a section that is explicitly labelled as
deprecated to help discourage future usage.