### PR TITLE
remove sentence with list of other aggrs

### DIFF
--- a/docs/asl/ref/bottomk.md
+++ b/docs/asl/ref/bottomk.md
@@ -19,7 +19,7 @@ After: /api/v1/graph?w=200&h=125&no_legend=1&s=e-3h&e=2012-01-01T07:00&palette=h
 
 In some cases it can be useful to see an aggregate summary of the other time series that were not
 part of the bottom set. This can be accomplished using the `:bottomk-others-$(aggr)` operators.
-Permitted aggregations are `avg`, `max`, `min`, and `sum`. For more details see:
+For more details see:
 
 - [:bottomk-others-avg](bottomk-others-avg.md)
 - [:bottomk-others-max](bottomk-others-max.md)

--- a/docs/asl/ref/topk.md
+++ b/docs/asl/ref/topk.md
@@ -19,7 +19,7 @@ After: /api/v1/graph?w=200&h=125&no_legend=1&s=e-3h&e=2012-01-01T07:00&palette=h
 
 In some cases it can be useful to see an aggregate summary of the other time series that were not
 part of the top set. This can be accomplished using the `:topk-others-$(aggr)` operators.
-Permitted aggregations are `avg`, `max`, `min`, and `sum`. For more details see:
+For more details see:
 
 - [:topk-others-avg](topk-others-avg.md)
 - [:topk-others-max](topk-others-max.md)


### PR DESCRIPTION
Some users reading this thought it was the list of summary
stats that could be used with the `topk` operator rather than
the list of aggregation options for the others. Remove the
list in the sentence as it is redundant with the links to
the specific operators.