### PR TITLE
update label to be consistent with tutorial

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,7 +40,7 @@ nav:
   - Alerting Philosophy: asl/alerting-philosophy.md
   - Double Exponential Smoothing: asl/des.md
   - Reference:
-    - Query:
+    - Choosing:
       - and: asl/ref/and.md
       - eq: asl/ref/eq.md
       - 'false': asl/ref/false.md


### PR DESCRIPTION
Change label for operators used to pick the matching time
series from `Query` to `Choosing`. This is consistent with
the tutorial and ASL course.