### PR TITLE
remove warning about docs not being ready

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,6 @@
 
 # Atlas
 
-!!! warning
-    These docs are still a work in progress. For now you should still refer to
-    the [Atlas Wiki](https://github.com/Netflix/atlas/wiki).
-
 <img src="images/atlas_logo.png" width="230" height="230" align="left"></img>
 
 Atlas was developed by Netflix to manage dimensional time series data for near real-time


### PR DESCRIPTION
This will now be considered the official docs for Atlas and
Spectator.