### PR TITLE
add new jvm stats to the metrics glossary

### DIFF
--- a/docs/api/time-parameters.md
+++ b/docs/api/time-parameters.md
@@ -144,4 +144,4 @@ month (`M`), and year (`Y`) are not supported. Examples:
 | P1DT37M    | One day and 37 minutes. |
 | PT5H6M    | Five hours and six minutes. |
 
-For more details see docs on [parsing durations](https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html#parse-java.lang.CharSequence-).
+For more details see docs on [parsing durations](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html#parse(java.lang.CharSequence)).

--- a/docs/asl/ref/format.md
+++ b/docs/asl/ref/format.md
@@ -7,7 +7,7 @@ str: String
 
 Format a string using a printf [style pattern][formatter].
 
-[formatter]: https://docs.oracle.com/javase/8/docs/api/java/util/Formatter.html
+[formatter]: https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/Formatter.html
 
 Example:
 

--- a/docs/asl/ref/re.md
+++ b/docs/asl/ref/re.md
@@ -58,4 +58,4 @@ case sensitive. Always try to have a simple prefix on the expression to allow fo
 matching of the expression. For more information on supported patterns, see the
 [Java regular expressions] documentation.
 
-[Java regular expressions]: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Pattern.html
+[Java regular expressions]: https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/regex/Pattern.html

--- a/docs/asl/ref/reic.md
+++ b/docs/asl/ref/reic.md
@@ -57,4 +57,4 @@ Notice that the casing for the query does not match the data. The regular expres
 be automatically anchored at the start. For more information on supported patterns, see the
 [Java regular expressions] documentation.
 
-[Java regular expressions]: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Pattern.html
+[Java regular expressions]: https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/regex/Pattern.html

--- a/docs/asl/ref/time.md
+++ b/docs/asl/ref/time.md
@@ -21,7 +21,7 @@ Generates a line based on the current time. Supported modes are:
 * days (since epoch)
 
 The mode can also be a value of the enum
-[ChronoField](https://docs.oracle.com/javase/8/docs/api/java/time/temporal/ChronoField.html).
+[ChronoField](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/temporal/ChronoField.html).
 
 Examples:
 

--- a/docs/spectator/core/clock.md
+++ b/docs/spectator/core/clock.md
@@ -25,7 +25,7 @@ Java usage example:
 long currentTime = registry.clock().wallTime();
 ```
 
-[System.currentTimeMillis()]: https://docs.oracle.com/javase/8/docs/api/java/lang/System.html#currentTimeMillis--
+[System.currentTimeMillis()]: https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/System.html#currentTimeMillis()
 [ntpd]: https://en.wikipedia.org/wiki/Ntpd
 
 ## Monotonic Time
@@ -79,5 +79,5 @@ timer.record(() -> {
 Assert.assertEquals(timer.totalTime(), 42L);
 ```
 
-[System.nanoTime()]: https://docs.oracle.com/javase/8/docs/api/java/lang/System.html#nanoTime--
+[System.nanoTime()]: https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/System.html#nanoTime()
 [ManualClock]: https://www.javadoc.io/doc/com.netflix.spectator/spectator-api/latest/com/netflix/spectator/api/ManualClock.html

--- a/docs/spectator/lang/java/ext/jvm-buffer-pools.md
+++ b/docs/spectator/lang/java/ext/jvm-buffer-pools.md
@@ -1,20 +1,19 @@
 # Buffer Pools
 
 Buffer pools, such as direct byte buffers, can be monitored at a high level using the
-[BufferPoolMXBean](http://docs.oracle.com/javase/7/docs/api/java/lang/management/BufferPoolMXBean.html)
+[BufferPoolMXBean](https://docs.oracle.com/en/java/javase/17/docs/api/java.management/java/lang/management/BufferPoolMXBean.html)
 provided by the JDK. 
 
 ## Getting Started
 
-To get information about buffer pools in spectator just setup registration of standard MXBeans.
-Note, if you are building an app at Netflix this should happen automatically via the normal
+To get information about buffer pools in Spectator, just setup registration of standard MXBeans.
+Note, if you are building an app at Netflix, then this should happen automatically via the normal
 platform initialization.
 
 ```java
-import com.netflix.spectator.api.Spectator;
 import com.netflix.spectator.jvm.Jmx;
 
-Jmx.registerStandardMXBeans(Spectator.registry());
+Jmx.registerStandardMXBeans(registry);
 ```
 
 ## Metrics

--- a/docs/spectator/lang/java/ext/jvm-classloading.md
+++ b/docs/spectator/lang/java/ext/jvm-classloading.md
@@ -1,0 +1,38 @@
+# Class Loading
+
+Uses the [ClassLoadingMXBean](https://docs.oracle.com/en/java/javase/17/docs/api/java.management/java/lang/management/ClassLoadingMXBean.html)
+provided by the JDK to monitor the number of classes loaded and unloaded.
+
+## Getting Started
+
+To get information about classloading in Spectator, just setup registration of standard MXBeans.
+Note, if you are building an app at Netflix, then this should happen automatically via the normal
+platform initialization.
+
+```java
+import com.netflix.spectator.jvm.Jmx;
+
+Jmx.registerStandardMXBeans(registry);
+```
+
+## Metrics
+
+### jvm.classloading.classesLoaded
+
+Counter reporting the number of classes loaded.
+
+**Unit:** classes/second
+
+**Dimensions:**
+
+* None.
+
+### jvm.classloading.classesUnloaded
+
+Counter reporting the number of classes unloaded.
+
+**Unit:** classes/second
+
+**Dimensions:**
+
+* None.

--- a/docs/spectator/lang/java/ext/jvm-compilation.md
+++ b/docs/spectator/lang/java/ext/jvm-compilation.md
@@ -1,0 +1,29 @@
+# Compilation
+
+Uses the [CompilationMXBean](https://docs.oracle.com/en/java/javase/17/docs/api/java.management/java/lang/management/CompilationMXBean.html)
+provided by the JDK to monitor the time spent compiling code, for each compiler name.
+
+## Getting Started
+
+To get information about compilation in Spectator, just setup registration of standard MXBeans.
+Note, if you are building an app at Netflix, then this should happen automatically via the normal
+platform initialization.
+
+```java
+import com.netflix.spectator.jvm.Jmx;
+
+Jmx.registerStandardMXBeans(registry);
+```
+
+## Metrics
+
+### jvm.compilation.compilationTime
+
+Counter reporting the amount of elapsed time spent in compilation. If multiple threads are used for
+compilation, then this value represents the summation of the time each thread spent in compilation. 
+
+**Unit:** seconds/second
+
+**Dimensions:**
+
+* `compiler`: name of the just-in-time (JIT) compiler

--- a/docs/spectator/lang/java/ext/jvm-gc-causes.md
+++ b/docs/spectator/lang/java/ext/jvm-gc-causes.md
@@ -6,7 +6,7 @@ file in the jdk and we include some information on what these mean for the appli
 
 ### System.gc__
 
-Something called [System.gc()](http://docs.oracle.com/javase/7/docs/api/java/lang/System.html#gc()).
+Something called [System.gc()](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/System.html#gc()).
 If you are seeing this once an hour it is likely related to the RMI GC interval. For more
 details see:
 
@@ -31,13 +31,13 @@ just before the jvm exits. The `-Xaprof` option was removed in java 8.
 ### JvmtiEnv_ForceGarbageCollection
 
 Something called the JVM tool interface function
-[ForceGarbageCollection](https://docs.oracle.com/javase/8/docs/platform/jvmti/jvmti.html#ForceGarbageCollection).
+[ForceGarbageCollection](https://docs.oracle.com/en/java/javase/17/docs/specs/jvmti.html#ForceGarbageCollection).
 Look at the `-agentlib` param to java to see what agents are configured.
 
 ### GCLocker_Initiated_GC
 
 The GC locker prevents GC from occurring when JNI code is in a
-[critical region](http://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/functions.html#GetPrimitiveArrayCritical_ReleasePrimitiveArrayCritical).
+[critical region](https://docs.oracle.com/en/java/javase/17/docs/specs/jni/functions.html#getprimitivearraycritical-releaseprimitivearraycritical).
 If GC is needed while a thread is in a critical region, then it will allow them to complete,
 i.e. call the corresponding release function. Other threads will not be permitted to enter a
 critical region. Once all threads are out of critical regions a GC event will be triggered. 
@@ -45,19 +45,19 @@ critical region. Once all threads are out of critical regions a GC event will be
 ### Heap_Inspection_Initiated_GC
 
 GC was initiated by an inspection operation on the heap. For example you can trigger this
-with [jmap](http://docs.oracle.com/javase/7/docs/technotes/tools/share/jmap.html):
+with [jmap](https://docs.oracle.com/en/java/javase/17/docs/specs/man/jmap.html):
 
 `$ jmap -histo:live <pid>`
 
 ### Heap_Dump_Initiated_GC
 
 GC was initiated before dumping the heap. For example you can trigger this with
-[jmap](http://docs.oracle.com/javase/7/docs/technotes/tools/share/jmap.html):
+[jmap](https://docs.oracle.com/en/java/javase/17/docs/specs/man/jmap.html):
 
 `$ jmap -dump:live,format=b,file=heap.out <pid>`
 
 Another common example would be clicking the Heap Dump button on the Monitor tab in
-[jvisualvm](http://docs.oracle.com/javase/7/docs/technotes/tools/share/jvisualvm.html).
+[VisualVM](https://visualvm.github.io/).
 
 ### WhiteBox_Initiated_Young_GC
 

--- a/docs/spectator/lang/java/ext/jvm-gc.md
+++ b/docs/spectator/lang/java/ext/jvm-gc.md
@@ -8,7 +8,7 @@ some basic GC logging and metrics.
 * [Metrics](#metrics)
 * [Alerting](#alerting)
 
-[GarbageCollectorMXBean]: http://docs.oracle.com/javase/7/docs/api/java/lang/management/GarbageCollectorMXBean.html
+[GarbageCollectorMXBean]: https://docs.oracle.com/en/java/javase/17/docs/api/java.management/java/lang/management/GarbageCollectorMXBean.html
 
 ## Getting Started
 
@@ -83,7 +83,9 @@ the amount allocated since the previous GC event.
 
 **Unit:** bytes/second
 
-**Dimensions:** n/a
+**Dimensions:**
+
+* None.
 
 ### jvm.gc.promotionRate
 
@@ -98,7 +100,9 @@ abs(oldGen.sizeAfterGC - oldGen.sizeBeforeGC)
 
 **Unit:** bytes/second
 
-**Dimensions:** n/a
+**Dimensions:**
+
+* None.
 
 ### jvm.gc.liveDataSize
 
@@ -111,7 +115,9 @@ of the memory pool:
 
 **Unit:** bytes
 
-**Dimensions:** n/a
+**Dimensions:**
+
+* None.
 
 ### jvm.gc.maxDataSize
 
@@ -120,7 +126,9 @@ live data size.
 
 **Unit:** bytes
 
-**Dimensions:** n/a
+**Dimensions:**
+
+* None.
 
 ### jvm.gc.pause
 
@@ -135,8 +143,8 @@ the typical values seen are `end_of_major_GC` and `end_of_minor_GC`.
 * `cause`: cause that instigated GC ([getGcCause]). For an explanation of common causes see the
 [GC causes](jvm-gc-causes.md) page.
 
-[getGcAction]: http://docs.oracle.com/javase/7/docs/jre/api/management/extension/com/sun/management/GarbageCollectionNotificationInfo.html#getGcAction()
-[getGcCause]: http://docs.oracle.com/javase/7/docs/jre/api/management/extension/com/sun/management/GarbageCollectionNotificationInfo.html#getGcCause()
+[getGcAction]: https://docs.oracle.com/en/java/javase/17/docs/api/jdk.management/com/sun/management/GarbageCollectionNotificationInfo.html#getGcAction()
+[getGcCause]: https://docs.oracle.com/en/java/javase/17/docs/api/jdk.management/com/sun/management/GarbageCollectionNotificationInfo.html#getGcCause()
 
 ### jvm.gc.concurrentPhaseTime
 

--- a/docs/spectator/lang/java/ext/jvm-memory-pools.md
+++ b/docs/spectator/lang/java/ext/jvm-memory-pools.md
@@ -1,20 +1,18 @@
 # Memory Pools
 
-Uses the [MemoryPoolMXBean](http://docs.oracle.com/javase/7/docs/api/java/lang/management/MemoryPoolMXBean.html)
-provided by the JDK to monitor the sizes of java memory spaces such as perm gen, eden, old
-gen, etc. 
+Uses the [MemoryPoolMXBean](https://docs.oracle.com/en/java/javase/17/docs/api/java.management/java/lang/management/MemoryPoolMXBean.html)
+provided by the JDK to monitor the sizes of java memory spaces such as perm gen, eden, old gen, etc. 
 
 ## Getting Started
 
-To get information about memory pools in spectator just setup registration of standard MXBeans.
-Note, if you are building an app at Netflix this should happen automatically via the normal
+To get information about memory pools in Spectator, just setup registration of standard MXBeans.
+Note, if you are building an app at Netflix, then this should happen automatically via the normal
 platform initialization.
 
 ```java
-import com.netflix.spectator.api.Spectator;
 import com.netflix.spectator.jvm.Jmx;
 
-Jmx.registerStandardMXBeans(Spectator.registry());
+Jmx.registerStandardMXBeans(registry);
 ```
 
 ## Metrics
@@ -29,12 +27,13 @@ is probably a better option.
 **Unit:** bytes
 
 **Dimensions:**
-see [metric dimensions](#metric-dimensions)
+
+* See [metric dimensions](#metric-dimensions).
 
 ### jvm.memory.committed
 
 Gauge reporting the current amount of memory committed. From the
-[javadocs](http://docs.oracle.com/javase/7/docs/api/java/lang/management/MemoryUsage.html),
+[javadocs](https://docs.oracle.com/en/java/javase/17/docs/api/java.management/java/lang/management/MemoryUsage.html),
 committed is:
 
 > The amount of memory (in bytes) that is guaranteed to be available for use by the Java
@@ -45,12 +44,13 @@ committed is:
 **Unit:** bytes 
 
 **Dimensions:**
-see [metric dimensions](#metric-dimensions)
+
+* See [metric dimensions](#metric-dimensions).
 
 ### jvm.memory.max
 
 Gauge reporting the max amount of memory that can be used. From the
-[javadocs](http://docs.oracle.com/javase/7/docs/api/java/lang/management/MemoryUsage.html),
+[javadocs](https://docs.oracle.com/en/java/javase/17/docs/api/java.management/java/lang/management/MemoryUsage.html),
 max is:
 
 > The maximum amount of memory (in bytes) that can be used for memory management. Its value
@@ -63,7 +63,8 @@ max is:
 **Unit:** bytes 
 
 **Dimensions:**
-see [metric dimensions](#metric-dimensions)
+
+* See [metric dimensions](#metric-dimensions).
 
 ## Metric Dimensions
 
@@ -72,4 +73,4 @@ All memory metrics have the following dimensions:
 * `id`: name of the memory pool being reported. The names of the pools vary depending on the
   garbage collector algorithm being used.
 * `memtype`: type of memory. It has two possible values: `HEAP` and `NON_HEAP`. For more
-  information see the javadocs for [MemoryType](http://docs.oracle.com/javase/7/docs/api/java/lang/management/MemoryType.html).
+  information see the javadocs for [MemoryType](https://docs.oracle.com/en/java/javase/17/docs/api/java.management/java/lang/management/MemoryType.html).

--- a/docs/spectator/lang/java/ext/jvm-threads.md
+++ b/docs/spectator/lang/java/ext/jvm-threads.md
@@ -1,0 +1,38 @@
+# Threads
+
+Uses the [ThreadMXBean](https://docs.oracle.com/en/java/javase/17/docs/api/java.management/java/lang/management/ThreadMXBean.html)
+provided by the JDK to monitor the number of active threads and threads started.
+
+## Getting Started
+
+To get information about threads in Spectator, just setup registration of standard MXBeans. Note,
+if you are building an app at Netflix, then this should happen automatically via the normal platform
+initialization.
+
+```java
+import com.netflix.spectator.jvm.Jmx;
+
+Jmx.registerStandardMXBeans(registry);
+```
+
+## Metrics
+
+### jvm.thread.threadCount
+
+Gauge reporting the number of active threads.
+
+**Unit:** threads
+
+**Dimensions:**
+
+* `id`: thread category, either `daemon` or `non-daemon`
+
+### jvm.thread.threadsStarted
+
+Counter reporting the number of threads started.
+
+**Unit:** threads/second
+
+**Dimensions:**
+
+* None.

--- a/docs/spectator/lang/java/ext/thread-pools.md
+++ b/docs/spectator/lang/java/ext/thread-pools.md
@@ -75,5 +75,5 @@ Gauge showing the current number of threads queued for execution.
 
 **Data Source:** `ThreadPoolExecutor#getQueue().size()`
 
-[ThreadPoolExecutor]: http://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ThreadPoolExecutor.html
+[ThreadPoolExecutor]: https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/concurrent/ThreadPoolExecutor.html
 [ThreadPoolMonitor]: https://www.javadoc.io/doc/com.netflix.spectator/spectator-api/latest/com/netflix/spectator/api/patterns/ThreadPoolMonitor.html

--- a/docs/spectator/lang/java/meters/gauge.md
+++ b/docs/spectator/lang/java/meters/gauge.md
@@ -124,7 +124,7 @@ represents the number of events since the system was initialized. An example of 
 is [ThreadPoolExecutor.getCompletedTaskCount], which returns the number of completed tasks on
 the thread pool.
 
-[ThreadPoolExecutor.getCompletedTaskCount]: https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ThreadPoolExecutor.html#getCompletedTaskCount--
+[ThreadPoolExecutor.getCompletedTaskCount]: https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/concurrent/ThreadPoolExecutor.html#getCompletedTaskCount()
 
 For sources like this, the `monitorMonotonicCounter` method can be used:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -244,9 +244,12 @@ nav:
       - Extensions:
         - JVM Stats:
           - Buffer Pools: spectator/lang/java/ext/jvm-buffer-pools.md
+          - Class Loading: spectator/lang/java/ext/jvm-classloading.md
+          - Compilation: spectator/lang/java/ext/jvm-compilation.md
           - Garbage Collection: spectator/lang/java/ext/jvm-gc.md
           - GC Causes: spectator/lang/java/ext/jvm-gc-causes.md
           - Memory Pools: spectator/lang/java/ext/jvm-memory-pools.md
+          - Threads: spectator/lang/java/ext/jvm-threads.md
           - Thread Pools: spectator/lang/java/ext/thread-pools.md
         - Log4j2 Appender: spectator/lang/java/ext/log4j2.md
         - Log4j1 Appender: spectator/lang/java/ext/log4j1.md

--- a/plugins/mkdocs-atlas-formatting-plugin/mkdocs_atlas_formatting_plugin/logconfig.py
+++ b/plugins/mkdocs-atlas-formatting-plugin/mkdocs_atlas_formatting_plugin/logconfig.py
@@ -7,7 +7,7 @@ def setup_logging(name: str, level: int = logging.INFO) -> logging:
     logger = logging.getLogger(f'{PLUGIN_NAME}.{name}')
     logger.setLevel(level)
     stream = logging.StreamHandler()
-    formatter = logging.Formatter('%(levelname)-7s -  %(message)s ')
+    formatter = logging.Formatter('%(levelname)-7s  -  %(message)s ')
     stream.setFormatter(formatter)
     if not len(logger.handlers):
         logger.addHandler(stream)

--- a/plugins/mkdocs-atlas-formatting-plugin/mkdocs_atlas_formatting_plugin/plugin.py
+++ b/plugins/mkdocs-atlas-formatting-plugin/mkdocs_atlas_formatting_plugin/plugin.py
@@ -16,7 +16,6 @@ class AtlasFormattingPlugin(BasePlugin):
     webserver: Optional[AtlasWebServer] = None
 
     def on_pre_build(self, config: Config) -> None:
-        logger.info('pre-build')
         self.webserver = AtlasWebServer()
 
     def on_page_content(self, html: str, page: Page, config: Config, files: Files) -> str:
@@ -27,3 +26,7 @@ class AtlasFormattingPlugin(BasePlugin):
         if config['site_url'] == 'https://netflix.github.io/atlas-docs/':
             logger.info('shutdown webserver')
             self.webserver.shutdown()
+
+    def on_build_error(self, error) -> None:
+        logger.info('shutdown webserver, due to error')
+        self.webserver.shutdown()


### PR DESCRIPTION
This supports the following PR in Spectator:
    
https://github.com/Netflix/spectator/pull/954

A second commit is bundled with this change which makes the atlas-formatting plugin resilient to `mkdocs` build errors.
