### PR TITLE
Remove linebreaks in code examples

### DIFF
--- a/docs/spectator/core/meters/dist-summary.md
+++ b/docs/spectator/core/meters/dist-summary.md
@@ -31,8 +31,7 @@ via a filter, or use one of the operators below to generate a useful response.
 To compute the average latency across an arbitrary group, use the [:dist-avg] function:
 
 @@@ atlas-stacklang
-/api/v1/graph?q=nf.cluster,foo,:eq,name,http.req.payload.size,:eq,:and,
-:dist-avg,(,nf.asg,),:by
+/api/v1/graph?q=nf.cluster,foo,:eq,name,http.req.payload.size,:eq,:and,:dist-avg,(,nf.asg,),:by
 @@@
 
 [:dist-avg]: ../../../asl/ref/dist-avg.md
@@ -42,8 +41,7 @@ To compute the average latency across an arbitrary group, use the [:dist-avg] fu
 To compute the maximum latency across a group, use [:dist-max]:
 
 @@@ atlas-stacklang
-/api/v1/graph?q=nf.cluster,foo,:eq,name,http.req.payload.size,:eq,:and,
-:dist-max,(,nf.asg,),:by
+/api/v1/graph?q=nf.cluster,foo,:eq,name,http.req.payload.size,:eq,:and,:dist-max,(,nf.asg,),:by
 @@@
 
 [:dist-max]: ../../../asl/ref/dist-max.md


### PR DESCRIPTION
Linebreaks break the resulting documentation (e.g. https://netflix.github.io/atlas-docs/spectator/core/meters/dist-summary/#average-measurement-dist-avg)