### PR TITLE
make offset warning more prominent

### DIFF
--- a/docs/asl/ref/offset.md
+++ b/docs/asl/ref/offset.md
@@ -5,6 +5,10 @@ Duration
 TimeSeriesExpr
 @@@
 
+!!! warning
+    Note that there is a deprecated `List[Duration]` variant that only modifes the presentation
+    at the end. It cannot be used along with math operations.
+
 Shift the time frame to use when fetching the data. This is used to look at a previous
 interval as a point of reference, e.g., day-over-day or week-over-week.
 
@@ -21,6 +25,3 @@ Before: /api/v1/graph?w=200&h=125&no_legend=1&s=e-3h&e=2012-01-01T07:00&tz=UTC&l
 After: /api/v1/graph?w=200&h=125&no_legend=1&s=e-3h&e=2012-01-01T07:00&tz=UTC&l=0&q=name,sps,:eq,(,name,),:by,PT1H,:offset
 Combined: /api/v1/graph?w=200&h=125&no_legend=1&s=e-3h&e=2012-01-01T07:00&tz=UTC&l=0&q=name,sps,:eq,(,name,),:by,:dup,PT1H,:offset
 @@@
-
-Note that there is a deprecated `List\[Duration\]` variant that returns `StyleExpr` instead 
-of `TimeSeriesExpr` and cannot be used with math operations.


### PR DESCRIPTION
Make notice about deprecated warning for offset
more prominent. It was pretty easy to overlook
when below the examples.