### PR TITLE
fix broken links

### DIFF
--- a/docs/api/graph/line-styles.md
+++ b/docs/api/graph/line-styles.md
@@ -1,4 +1,4 @@
-There are four [line styles](style-ls) available:
+There are four [line styles](../../asl/ref/ls.md) available:
 
 * [Line](#line)
 * [Area](#area)
@@ -27,8 +27,8 @@ The default style is line.
 
 ## Area
 
-Area will fill the space between the line and 0 on the Y-axis. The [alpha](style-alpha) setting
-is just used to help visualize the overlap.
+Area will fill the space between the line and 0 on the Y-axis. The [alpha](../../asl/ref/alpha.md)
+setting is just used to help visualize the overlap.
 
 @@@ atlas-uri { hilite=:area }
 /api/v1/graph?e=2012-01-01T00:00&no_legend=1&q=name,sps,:eq,(,nf.cluster,),:by,:area,40,:alpha&s=e-1w
@@ -74,7 +74,7 @@ Similarly for negative values:
 
 ## Stacked Percentage
 
-The [stack](#stack) style can be combined with the [:pct](math-pct) operator to get a stacked
+The [stack](#stack) style can be combined with the [:pct](../../asl/ref/pct.md) operator to get a stacked
 percentage chart for a group by:
 
 @@@ atlas-uri { hilite=:pct }

--- a/docs/asl/alerting-expressions.md
+++ b/docs/asl/alerting-expressions.md
@@ -32,7 +32,7 @@ when everything is fine.
 
 Our threshold alert above will trigger if the CPU usage is ever recorded to be above the threshold.
 Alert conditions are often combined with a check for the number of occurrences. This is done by
-using the [:rolling-count](stateful-rolling-count) operator to get a line showing how many times
+using the [:rolling-count](ref/rolling-count.md) operator to get a line showing how many times
 the input signal has been true withing a specified window and then applying a second threshold to
 the rolling count.
 

--- a/docs/asl/ref/fdiv.md
+++ b/docs/asl/ref/fdiv.md
@@ -17,7 +17,7 @@ Input 2 | 1.0 | 0.0 | 0.0 | NaN | NaN |
 Note in many cases `NaN` will appear in data, e.g., if a node was brought up and started
 reporting in the middle of the time window for the graph. Zero divided by zero can also
 occur due to lack of activity in some windows. Unless you really need strict floating
-point behavior, use the [div](math-div) operator to get behavior more appropriate for
+point behavior, use the [div](div.md) operator to get behavior more appropriate for
 graphs.
 
 Example dividing a constant:

--- a/docs/asl/ref/fsub.md
+++ b/docs/asl/ref/fsub.md
@@ -17,7 +17,7 @@ Input 2 | 1.0 | 0.0 | 0.0 | NaN | NaN |
 Note in many cases `NaN` will appear in data, e.g., if a node was brought up and started
 reporting in the middle of the time window for the graph. This can lead to confusing
 behavior if added to a line that does have data as the result will be `NaN`. Use the
-[sub](math-sub) operator to treat `NaN` values as zero for combining with other time
+[sub](sub.md) operator to treat `NaN` values as zero for combining with other time
 series.
 
 Example subtracting a constant:


### PR DESCRIPTION
Fix a handful of broken links to operations in the ASL reference.