### PR TITLE
Fix query sample for Timer meter

### DIFF
--- a/docs/spectator/core/meters/timer.md
+++ b/docs/spectator/core/meters/timer.md
@@ -34,8 +34,7 @@ response.
 To compute the average latency across an arbitrary group, use the [:dist-avg] function:
 
 @@@ atlas-stacklang
-/api/v1/graph?q=nf.cluster,foo,:eq,name,http.req.latency,:eq,:and,
-:dist-avg,(,nf.asg,),:by
+/api/v1/graph?q=nf.cluster,foo,:eq,name,http.req.latency,:eq,:and,:dist-avg,(,nf.asg,),:by
 @@@
 
 [:dist-avg]: ../../../asl/ref/dist-avg.md
@@ -45,8 +44,7 @@ To compute the average latency across an arbitrary group, use the [:dist-avg] fu
 To compute the maximum latency across a group, use [:dist-max]:
 
 @@@ atlas-stacklang
-/api/v1/graph?q=nf.cluster,foo,:eq,name,http.req.latency,:eq,:and,
-:dist-max,(,nf.asg,),:by
+/api/v1/graph?q=nf.cluster,foo,:eq,name,http.req.latency,:eq,:and,:dist-max,(,nf.asg,),:by
 @@@
 
 [:dist-max]: ../../../asl/ref/dist-max.md


### PR DESCRIPTION
Currently the [built doc](https://netflix.github.io/atlas-docs/spectator/core/meters/timer/#average-measurement-dist-avg) does not show the sample query correctly for `Timer`. The reason is that, the `atlas-stacklang` syntax does not like multiple lines. To get that solved, let's just merge the lines together.

