### PR TITLE
follow redirects when fetching atlas jar

### DIFF
--- a/plugins/mkdocs-atlas-formatting-plugin/mkdocs_atlas_formatting_plugin/atlaswebserver.py
+++ b/plugins/mkdocs-atlas-formatting-plugin/mkdocs_atlas_formatting_plugin/atlaswebserver.py
@@ -60,7 +60,7 @@ class AtlasWebServer:
 
         logger.info(f'download {url}')
 
-        r = requests.get(url, stream=True)
+        r = requests.get(url, stream=True, allow_redirects=True)
 
         with open(jar, 'wb') as f:
             for chunk in r.iter_content(chunk_size=1024):


### PR DESCRIPTION
Github now does a redirect when trying to fetch the artifacts for a release.