### PR TITLE
add note to offset about streaming

### DIFF
--- a/docs/asl/ref/offset.md
+++ b/docs/asl/ref/offset.md
@@ -10,7 +10,9 @@ TimeSeriesExpr
     at the end. It cannot be used along with math operations.
 
 Shift the time frame to use when fetching the data. This is used to look at a previous
-interval as a point of reference, e.g., day-over-day or week-over-week.
+interval as a point of reference, e.g., day-over-day or week-over-week. Offset cannot be
+used with streaming execution of the query, consider using the [delay](delay.md) operator
+for short intervals to detect a change.
 
 Examples:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,7 +54,6 @@ nav:
       - le: asl/ref/le.md
       - lt: asl/ref/lt.md
       - not: asl/ref/not.md
-      - offset: asl/ref/offset.md
       - or: asl/ref/or.md
       - re: asl/ref/re.md
       - reic: asl/ref/reic.md
@@ -118,6 +117,7 @@ nav:
       - min: asl/ref/min.md
       - neg: asl/ref/neg.md
       - node-avg: asl/ref/node-avg.md
+      - offset: asl/ref/offset.md
       - or: asl/ref/or.md
       - pct: asl/ref/pct.md
       - per-step: asl/ref/per-step.md


### PR DESCRIPTION
Clarify that offset cannot be used with streaming queries and delay should be considered instead.