### PR TITLE
remove todo section of servo migration guide

### DIFF
--- a/docs/spectator/lang/java/servo-migration.md
+++ b/docs/spectator/lang/java/servo-migration.md
@@ -378,11 +378,7 @@ Spectator:
 
 ### BucketTimer
 
-TODO: find sandbox documentation or remove reference
-
-See the general overview of [registration differences](#registration) and the summary of
-[sandbox documentation](Sandbox). In Spectator, BucketTimer is provided in the sandbox extension
-library and may change in future as we gain more experience using it.
+See the general overview of [registration differences](#registration).
 
 Servo:
 


### PR DESCRIPTION
BucketTimer is supported as part of histogram ext and the sandbox version doesn't need to be used.