### PR TITLE
update to atlas 1.7.5

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,8 +18,8 @@ machine. For other common tasks see:
 To quickly run a version with some synthetic sample data:
 
 ```
-$ curl -LO https://github.com/Netflix/atlas/releases/download/v1.6.5/atlas-1.6.5-standalone.jar
-$ java -jar atlas-1.6.5-standalone.jar
+$ curl -LO https://github.com/Netflix/atlas/releases/download/v1.7.5/atlas-standalone-1.7.5.jar
+$ java -jar atlas-standalone-1.7.5.jar
 ```
 
 ## Explore Available Tags
@@ -60,15 +60,15 @@ $ curl -Lo graph.png 'http://localhost:7101/api/v1/graph?q=name,ssCpuUser,:eq,:a
 Run an instance with a configuration to use the memory storage:
 
 ```
-$ curl -Lo memory.conf https://raw.githubusercontent.com/Netflix/atlas/v1.6.x/conf/memory.conf
-$ java -jar atlas-1.6.5-standalone.jar memory.conf
+$ curl -Lo memory.conf https://raw.githubusercontent.com/Netflix/atlas/v1.7.x/conf/memory.conf
+$ java -jar atlas-standalone-1.7.5.jar memory.conf
 ```
 
 Now we can send some data to it. To quickly get started there is a sample script to send in
 some data:
 
 ```
-$ curl -Lo publish-test.sh https://raw.githubusercontent.com/Netflix/atlas/v1.6.x/scripts/publish-test.sh
+$ curl -Lo publish-test.sh https://raw.githubusercontent.com/Netflix/atlas/v1.7.x/scripts/publish-test.sh
 $ chmod 755 publish-test.sh
 $ ./publish-test.sh
 ```


### PR DESCRIPTION
Update the getting started example to 1.7.5. The 1.6.x branch is no longer maintained.