### PR TITLE
Improved Portability of setup-venv.sh Script.

### DIFF
--- a/setup-venv.sh
+++ b/setup-venv.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if ! which python3 > /dev/null; then
+if ! command -v python3 > /dev/null; then
     echo "python3 is not available - please install"
     exit 1
 fi


### PR DESCRIPTION
This pull request updates the `setup-venv.sh` script to use `command -v python3` instead of `which python3` for checking the presence of Python 3. This change enhances the script's compatibility across different Unix-like systems by adhering to POSIX standards, ensuring better portability and reliability.