### PR TITLE
fix warnings

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,13 +6,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: '17'
           distribution: 'zulu'
+
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.x
+          python-version: '3'
+
       - run: pip install -r requirements.txt
+
       - run: mkdocs build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,14 +11,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: '17'
           distribution: 'zulu'
+
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.x
+          python-version: '3'
+
       - run: pip install -r requirements.txt
+
       - run: git fetch origin gh-pages:gh-pages
+
       - run: mkdocs gh-deploy

--- a/plugins/mkdocs-atlas-formatting-plugin/mkdocs_atlas_formatting_plugin/block.py
+++ b/plugins/mkdocs-atlas-formatting-plugin/mkdocs_atlas_formatting_plugin/block.py
@@ -24,11 +24,11 @@ class Block:
         ATLAS_URI
     ]
 
-    example_pattern = re.compile('([^:]+): (.+)')
-    options_pattern = re.compile('.+@@@ ([a-z\\-]+)(?:$| { (.+) })')
-    query_pattern = re.compile('.*q=([^&]+)')
-    number_pattern = re.compile('^[-+]?\d+(.\d)?$')
-    color_pattern = re.compile('^1(,1)+$')
+    example_pattern = re.compile(r'([^:]+): (.+)')
+    options_pattern = re.compile(r'.+@@@ ([a-z\\-]+)(?:$| { (.+) })')
+    query_pattern = re.compile(r'.*q=([^&]+)')
+    number_pattern = re.compile(r'^[-+]?\d+(.\d)?$')
+    color_pattern = re.compile(r'^1(,1)+$')
 
     def __init__(self, webserver: Optional[NoopWebserver] = None) -> None:
         self.webserver: AtlasWebServer = AtlasWebServer() if not webserver else webserver


### PR DESCRIPTION
With Python 3.12, we are getting syntax warnings that the `\d` sequence is
invalid. The best practice is to make regex compiles raw strings.