### PR TITLE
update spectator-py docs for 1.0.3

### DIFF
--- a/docs/spectator/lang/py/meters/age-gauge.md
+++ b/docs/spectator/lang/py/meters/age-gauge.md
@@ -7,7 +7,7 @@ Time Since Last Success alerting pattern.
 To set a specific time as the last success:
 
 ```python
-from spectator.registry import Registry
+from spectator import Registry
 
 registry = Registry()
 registry.age_gauge("time.sinceLastSuccess").set(1611081000)
@@ -19,7 +19,7 @@ registry.age_gauge_with_id(last_success).set(1611081000)
 To set `now()` as the last success:
 
 ```python
-from spectator.registry import Registry
+from spectator import Registry
 
 registry = Registry()
 registry.age_gauge("time.sinceLastSuccess").now()

--- a/docs/spectator/lang/py/meters/counter.md
+++ b/docs/spectator/lang/py/meters/counter.md
@@ -7,7 +7,7 @@ be used to convert them back into a value-per-step on a graph.
 Call `increment()` when an event occurs:
 
 ```python
-from spectator.registry import Registry
+from spectator import Registry
 
 registry = Registry()
 registry.counter("server.numRequests").increment()
@@ -20,7 +20,7 @@ You can also pass a value to `increment()`. This is useful when a collection of 
 together:
 
 ```python
-from spectator.registry import Registry
+from spectator import Registry
 
 registry = Registry()
 registry.counter("queue.itemsAdded").increment(10)

--- a/docs/spectator/lang/py/meters/dist-summary.md
+++ b/docs/spectator/lang/py/meters/dist-summary.md
@@ -9,7 +9,7 @@ This means that a `4K` tick label will represent 4 kilobytes, rather than 4 kilo
 Call `record()` with a value:
 
 ```python
-from spectator.registry import Registry
+from spectator import Registry
 
 registry = Registry()
 registry.distribution_summary("server.requestSize").record(10)

--- a/docs/spectator/lang/py/meters/gauge.md
+++ b/docs/spectator/lang/py/meters/gauge.md
@@ -9,7 +9,7 @@ higher or lower at some point during interval, but that is not known.
 Call `set()` with a value:
 
 ```python
-from spectator.registry import Registry
+from spectator import Registry
 
 registry = Registry()
 registry.gauge("server.queueSize").set(10)
@@ -23,7 +23,7 @@ not need to be collected on a tight 1-minute schedule to ensure that Atlas shows
 graphs. A custom TTL may be configured for gauges. SpectatorD enforces a minimum TTL of 5 seconds.
 
 ```python
-from spectator.registry import Registry
+from spectator import Registry
 
 registry = Registry()
 registry.gauge("server.queueSize", ttl_seconds=120).set(10)

--- a/docs/spectator/lang/py/meters/max-gauge.md
+++ b/docs/spectator/lang/py/meters/max-gauge.md
@@ -6,7 +6,7 @@ standard Gauges, Max Gauges do not continue to report to the backend, and there 
 Call `set()` with a value:
 
 ```python
-from spectator.registry import Registry
+from spectator import Registry
 
 registry = Registry()
 registry.max_gauge("server.queueSize").set(10)

--- a/docs/spectator/lang/py/meters/monotonic-counter-uint.md
+++ b/docs/spectator/lang/py/meters/monotonic-counter-uint.md
@@ -8,7 +8,7 @@ Call `set()` when an event occurs:
 
 ```python
 from ctypes import c_uint64
-from spectator.registry import Registry
+from spectator import Registry
 
 registry = Registry()
 registry.monotonic_counter_uint("iface.bytes").set(c_uint64(1))

--- a/docs/spectator/lang/py/meters/monotonic-counter.md
+++ b/docs/spectator/lang/py/meters/monotonic-counter.md
@@ -7,7 +7,7 @@ these values, at the expense of a slower time-to-first metric.
 Call `set()` when an event occurs:
 
 ```python
-from spectator.registry import Registry
+from spectator import Registry
 
 registry = Registry()
 registry.monotonic_counter("iface.bytes").set(10)

--- a/docs/spectator/lang/py/meters/percentile-dist-summary.md
+++ b/docs/spectator/lang/py/meters/percentile-dist-summary.md
@@ -11,7 +11,7 @@ added to Percentile Distribution Summaries and ensure that they have a small bou
 Call `record()` with a value:
 
 ```python
-from spectator.registry import Registry
+from spectator import Registry
 
 registry = Registry()
 registry.pct_distribution_summary("server.requestSize").record(10)

--- a/docs/spectator/lang/py/meters/percentile-timer.md
+++ b/docs/spectator/lang/py/meters/percentile-timer.md
@@ -11,7 +11,7 @@ Timers and ensure that they have a small bounded cardinality.
 Call `record()` with a value:
 
 ```python
-from spectator.registry import Registry
+from spectator import Registry
 
 registry = Registry()
 registry.pct_timer("server.requestLatency").record(0.01)
@@ -25,8 +25,7 @@ the number of seconds that have elapsed while executing a block of code:
 
 ```python
 import time
-from spectator.registry import Registry
-from spectator.stopwatch import StopWatch
+from spectator import Registry, StopWatch
 
 registry = Registry()
 thread_sleep = registry.pct_timer("thread.sleep")

--- a/docs/spectator/lang/py/meters/timer.md
+++ b/docs/spectator/lang/py/meters/timer.md
@@ -3,7 +3,7 @@ A Timer is used to measure how long (in seconds) some event is taking.
 Call `record()` with a value:
 
 ```python
-from spectator.registry import Registry
+from spectator import Registry
 
 registry = Registry()
 registry.timer("server.requestLatency").record(0.01)
@@ -17,8 +17,7 @@ the number of seconds that have elapsed while executing a block of code:
 
 ```python
 import time
-from spectator.registry import Registry
-from spectator.stopwatch import StopWatch
+from spectator import Registry, StopWatch
 
 registry = Registry()
 thread_sleep = registry.timer("thread.sleep")

--- a/docs/spectator/lang/py/migrations.md
+++ b/docs/spectator/lang/py/migrations.md
@@ -63,8 +63,7 @@ After:
 
 ```python
 import time
-from spectator.registry import Registry
-from spectator.stopwatch import StopWatch
+from spectator import Registry, StopWatch
 
 registry = Registry()
 server_latency = registry.pct_timer("serverLatency")
@@ -99,7 +98,7 @@ GlobalRegistry.gauge("server.queueSize", ttl_seconds=120).set(10)
 After:
 
 ```python
-from spectator.registry import Registry
+from spectator import Registry
 
 registry = Registry()
 registry.gauge("server.queueSize", ttl_seconds=120).set(10)


### PR DESCRIPTION
Top-level imports were added, which simplifies usage, so relevant examples were updated. The main code examples were simplified a bit.