### PR TITLE
clarify spectator output location advice

### DIFF
--- a/docs/spectator/lang/go/usage.md
+++ b/docs/spectator/lang/go/usage.md
@@ -184,16 +184,16 @@ Writers can be configured through `spectator.Config.Location`.
 
 Possible values are:
 
-* `""`: Empty string will default to `udp`.
-* `none`: Configures a no-op writer that does nothing. Can be used to disable metrics collection.
-* `memory`: Writes metrics to memory. Useful for testing.
-* `stderr`: Writes metrics to stderr.
-* `stdout`: Writes metrics to stdout.
-* `udp`    - Write metrics to the default spectatord UDP port. This is the default value.
-* `unix`   - Write metrics to the default spectatord Unix Domain Socket. Useful for high-volume scenarios.
-* `file:///path/to/file`: Writes metrics to a custom file (e.g. `file:///tmp/foo/bar`).
-* `udp://host:port`: Writes metrics to a custom UDP socket (e.g. `udp://127.0.0.1:1235`).
-* `unix:///path/to/socket`: Writes metrics to a custom Unix domain socket (e.g. `unix:///tmp/some.socket`).
+* `""`     - Empty string will default to `udp`.
+* `none`   - A no-op writer that does nothing. Used to disable metrics collection.
+* `memory` - Write to memory. Useful for testing.
+* `stderr` - Write to standard error for the process.
+* `stdout` - Write to standard output for the process.
+* `udp`    - Write to the default UDP port for `spectatord`. This is the default location.
+* `unix`   - Write to the default Unix Domain Socket for `spectatord`. Useful for high-volume scenarios.
+* `file:///path/to/file`   - Write to a custom file (e.g. `file:///tmp/foo/bar`).
+* `udp://host:port`        - Write to a custom UDP socket (e.g. `udp://127.0.0.1:1235`).
+* `unix:///path/to/socket` - Write to a custom Unix domain socket (e.g. `unix:///tmp/some.socket`).
 
 Location can also be set through the environment variable `SPECTATOR_OUTPUT_LOCATION`. If both are set,
 the environment variable takes precedence over the passed config. 

--- a/docs/spectator/lang/nodejs/usage.md
+++ b/docs/spectator/lang/nodejs/usage.md
@@ -335,15 +335,13 @@ in the `Registry`:
 If you need to override the default output location (UDP) of the `Registry`, then you can set a
 `Config` class location to one of the following supported values:
 
-* `none`   - Disable output.
-* `memory` - Write to memory.
+* `none`   - A no-op writer that does nothing. Used to disable metrics collection.
+* `memory` - Write to memory.  Useful for testing.
 * `stderr` - Write to standard error for the process.
-* `stdout` - Write to standard out for the process.
-* `udp`    - Write to the default UDP port for `spectatord`.
-* `unix`   - Write to the default Unix domain socket for `spectatord`.
+* `stdout` - Write to standard output for the process.
+* `udp`    - Write to the default UDP port for `spectatord`. This is the default location.
 * `file://$path_to_file` - Write to a custom file (e.g. `file:///tmp/foo/bar`).
 * `udp://$host:$port`    - Write to a custom UDP socket (e.g. `udp://127.0.0.1:1235`).
-* `unix://$path_to_file` - Write to a custom Unix domain socket (e.g. `unix:///tmp/some.socket`).
 
 The `SPECTATOR_OUTPUT_LOCATION` environment variable accepts the same values, and can be used to
 override the value provided to the `Config` class, which may be useful in CI/CD contexts. For
@@ -352,6 +350,23 @@ example, if you want to disable metrics publishing from the `Registry`, then you
 ```shell
 export SPECTATOR_OUTPUT_LOCATION=none
 ```
+
+### Unix Domain Sockets
+
+Unix Domain Sockets are not supported in this library, because Node.js removed the `unix_dgram`
+package from the standard library in 2011, as a part of portability concerns for Windows ([#29339]).
+
+There is a third-party [node-unix-dgram] library, but it contains C++ source code, which
+complicates the build, and it introduces synchronous calls in the context of callbacks. We want
+this library to be as low-friction as possible, so we will not adopt this package. If you need
+UDS support, then use the C++, Go, or Python libraries instead.
+
+This situation is similar to the JVM not adding support until version 16+ and the lack of
+adoption in the Java thin-client ([Unix Domain Socket Address]).
+
+[#29339]: https://github.com/nodejs/node/issues/29339
+[node-unix-dgram]: https://github.com/bnoordhuis/node-unix-dgram
+[Unix Domain Socket Address]: https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/net/UnixDomainSocketAddress.html
 
 ## Batch Usage
 

--- a/docs/spectator/lang/py/usage.md
+++ b/docs/spectator/lang/py/usage.md
@@ -274,12 +274,12 @@ in the `Registry`:
 If you need to override the default output location (UDP) of the `Registry`, then you can set a
 `Config` class location to one of the following supported values:
 
-* `none`   - Disable output.
-* `memory` - Write to memory.
+* `none`   - A no-op writer that does nothing. Used to disable metrics collection.
+* `memory` - Write to memory. Useful for testing.
 * `stderr` - Write to standard error for the process.
-* `stdout` - Write to standard out for the process.
-* `udp`    - Write to the default UDP port for `spectatord`.
-* `unix`   - Write to the default Unix domain socket for `spectatord`.
+* `stdout` - Write to standard output for the process.
+* `udp`    - Write to the default UDP port for `spectatord`. This is the default location.
+* `unix`   - Write to the default Unix Domain Socket for `spectatord`.  Useful for high-volume scenarios.
 * `file://$path_to_file` - Write to a custom file (e.g. `file:///tmp/foo/bar`).
 * `udp://$host:$port`    - Write to a custom UDP socket (e.g. `udp://127.0.0.1:1235`).
 * `unix://$path_to_file` - Write to a custom Unix domain socket (e.g. `unix:///tmp/some.socket`).


### PR DESCRIPTION
The spectator-js client does not support Unix Domain Sockets.