### PR TITLE
docs cleanup: add concept/pattern pages for remaining meter types

### DIFF
--- a/docs/spectator/core/meters/max-gauge.md
+++ b/docs/spectator/core/meters/max-gauge.md
@@ -1,0 +1,23 @@
+# Max Gauge
+
+A Max Gauge is a value sampled at a point in time, but reported to the backend as the
+**maximum** value observed during the reporting interval rather than the last-write-wins
+behavior of a standard [Gauge](gauge.md).
+
+This is useful when you want to make sure spikes are visible rather than missed between
+samples. For example, when tracking a queue depth that fluctuates rapidly within a
+reporting interval, a Max Gauge ensures the peak is preserved.
+
+Unlike a standard Gauge, Max Gauges do **not** continue to report after the last update
+and do not have a TTL. Once the reporting interval ends, the max is flushed and the next
+interval starts fresh.
+
+## Languages
+
+### First-Class Support
+
+* [C++](../../lang/cpp/meters/max-gauge.md)
+* [Go](../../lang/go/meters/max-gauge.md)
+* [Java](../../lang/java/meters/max-gauge.md)
+* [Node.js](../../lang/nodejs/meters/max-gauge.md)
+* [Python](../../lang/py/meters/max-gauge.md)

--- a/docs/spectator/lang/cpp/meters/age-gauge.md
+++ b/docs/spectator/lang/cpp/meters/age-gauge.md
@@ -1,5 +1,7 @@
 # Age Gauge
 
+See [Age Gauge](../../../patterns/age-gauge.md) for the concept.
+
 The value is the time in seconds since the epoch at which an event has successfully occurred, or
 `0` to use the current time in epoch seconds. After an Age Gauge has been set, it will continue
 reporting the number of seconds since the last time recorded, for as long as the SpectatorD

--- a/docs/spectator/lang/cpp/meters/max-gauge.md
+++ b/docs/spectator/lang/cpp/meters/max-gauge.md
@@ -1,5 +1,7 @@
 # Max Gauge
 
+See [Max Gauge](../../../core/meters/max-gauge.md) for the concept.
+
 The value is a number that is sampled at a point in time, but it is reported as a maximum Gauge
 value to the backend. This ensures that only the maximum value observed during a reporting interval
 is sent to the backend, thus over-riding the last-write-wins semantics of standard Gauges. Unlike

--- a/docs/spectator/lang/cpp/meters/monotonic-counter-uint.md
+++ b/docs/spectator/lang/cpp/meters/monotonic-counter-uint.md
@@ -1,5 +1,7 @@
 # Monotonic Counter (uint64)
 
+See [Monotonic Counter](../../../patterns/monotonic-counter.md) for the concept (uint64 variant).
+
 A Monotonic Counter (uint64) is used to measure the rate at which an event is occurring, when the
 source data is a monotonically increasing number. A minimum of two samples must be sent, in order to
 calculate a delta value and report it to the backend as a rate-per-second. A variety of networking

--- a/docs/spectator/lang/cpp/meters/monotonic-counter.md
+++ b/docs/spectator/lang/cpp/meters/monotonic-counter.md
@@ -1,5 +1,7 @@
 # Monotonic Counter
 
+See [Monotonic Counter](../../../patterns/monotonic-counter.md) for the concept.
+
 A Monotonic Counter (float) is used to measure the rate at which an event is occurring, when the
 source data is a monotonically increasing number. A minimum of two samples must be sent, in order to
 calculate a delta value and report it to the backend as a rate-per-second. A variety of networking

--- a/docs/spectator/lang/cpp/meters/percentile-dist-summary.md
+++ b/docs/spectator/lang/cpp/meters/percentile-dist-summary.md
@@ -1,5 +1,7 @@
 # Percentile Distribution Summary
 
+See [Percentile Distribution Summary](../../../patterns/percentile-dist-summary.md) for the concept.
+
 The value tracks the distribution of events, with percentile estimates. It is similar to a
 `PercentileTimer`, but more general, because the size does not have to be a period of time.
 

--- a/docs/spectator/lang/go/meters/age-gauge.md
+++ b/docs/spectator/lang/go/meters/age-gauge.md
@@ -1,5 +1,7 @@
 # Age Gauge
 
+See [Age Gauge](../../../patterns/age-gauge.md) for the concept.
+
 The value is the time in seconds since the epoch at which an event has successfully occurred, or
 `0` to use the current time in epoch seconds. After an Age Gauge has been set, it will continue
 reporting the number of seconds since the last time recorded, for as long as the SpectatorD

--- a/docs/spectator/lang/go/meters/max-gauge.md
+++ b/docs/spectator/lang/go/meters/max-gauge.md
@@ -1,5 +1,7 @@
 # Max Gauge
 
+See [Max Gauge](../../../core/meters/max-gauge.md) for the concept.
+
 The value is a number that is sampled at a point in time, but it is reported as a maximum Gauge
 value to the backend. This ensures that only the maximum value observed during a reporting interval
 is sent to the backend, thus over-riding the last-write-wins semantics of standard Gauges. Unlike

--- a/docs/spectator/lang/go/meters/monotonic-counter-uint.md
+++ b/docs/spectator/lang/go/meters/monotonic-counter-uint.md
@@ -1,5 +1,7 @@
 # Monotonic Counter (uint64)
 
+See [Monotonic Counter](../../../patterns/monotonic-counter.md) for the concept (uint64 variant).
+
 A Monotonic Counter (uint64) is used to measure the rate at which an event is occurring, when the
 source data is a monotonically increasing number. A minimum of two samples must be sent, in order to
 calculate a delta value and report it to the backend as a rate-per-second. A variety of networking

--- a/docs/spectator/lang/go/meters/monotonic-counter.md
+++ b/docs/spectator/lang/go/meters/monotonic-counter.md
@@ -1,5 +1,7 @@
 # Monotonic Counter
 
+See [Monotonic Counter](../../../patterns/monotonic-counter.md) for the concept.
+
 A Monotonic Counter (float) is used to measure the rate at which an event is occurring, when the
 source data is a monotonically increasing number. A minimum of two samples must be sent, in order to
 calculate a delta value and report it to the backend as a rate-per-second. A variety of networking

--- a/docs/spectator/lang/go/meters/percentile-dist-summary.md
+++ b/docs/spectator/lang/go/meters/percentile-dist-summary.md
@@ -1,5 +1,7 @@
 # Percentile Distribution Summary
 
+See [Percentile Distribution Summary](../../../patterns/percentile-dist-summary.md) for the concept.
+
 The value tracks the distribution of events, with percentile estimates. It is similar to a
 `PercentileTimer`, but more general, because the size does not have to be a period of time.
 

--- a/docs/spectator/lang/java/meters/age-gauge.md
+++ b/docs/spectator/lang/java/meters/age-gauge.md
@@ -1,0 +1,29 @@
+# Age Gauge
+
+See [Age Gauge](../../../patterns/age-gauge.md) for the concept.
+
+Java does not have a dedicated Age Gauge meter. The equivalent is a [Polled Meter](../../../patterns/polled-meter.md)
+that computes `now - lastSuccessTimestamp` on each poll:
+
+```java
+public class Job {
+
+  private final AtomicLong lastSuccess;
+
+  @Inject
+  public Job(Registry registry) {
+    lastSuccess = PolledMeter.using(registry)
+        .withName("job.timeSinceLastSuccess")
+        .monitorValue(
+            new AtomicLong(registry.clock().wallTime() / 1000),
+            ts -> (registry.clock().wallTime() / 1000) - ts.get());
+  }
+
+  public void onSuccess() {
+    lastSuccess.set(registry.clock().wallTime() / 1000);
+  }
+}
+```
+
+This reports the seconds elapsed since the last successful run, which is the basis for the
+Time Since Last Success alerting pattern.

--- a/docs/spectator/lang/java/meters/max-gauge.md
+++ b/docs/spectator/lang/java/meters/max-gauge.md
@@ -1,0 +1,26 @@
+# Max Gauge
+
+See [Max Gauge](../../../core/meters/max-gauge.md) for the concept.
+
+Create one via the [Registry](../registry/overview.md):
+
+```java
+public class Queue {
+
+  private final Gauge queueDepth;
+
+  @Inject
+  public Queue(Registry registry) {
+    queueDepth = registry.maxGauge("queue.depth");
+  }
+
+  public void enqueue(Object obj) {
+    impl.enqueue(obj);
+    queueDepth.set(impl.size());
+  }
+}
+```
+
+`Registry.maxGauge(...)` returns a [`Gauge`](https://static.javadoc.io/com.netflix.spectator/spectator-api/latest/com/netflix/spectator/api/Gauge.html)
+that retains the maximum value seen during a reporting interval and resets at the end of the
+interval.

--- a/docs/spectator/lang/java/meters/monotonic-counter.md
+++ b/docs/spectator/lang/java/meters/monotonic-counter.md
@@ -1,0 +1,26 @@
+# Monotonic Counter
+
+See [Monotonic Counter](../../../patterns/monotonic-counter.md) for the concept.
+
+Java does not expose a dedicated monotonic counter meter; the equivalent is the
+[Polled Meter](../../../patterns/polled-meter.md) helper's `monitorMonotonicCounter`, which
+periodically samples a function returning the current absolute value and reports the
+per-second rate of the delta:
+
+```java
+public class Worker {
+
+  @Inject
+  public Worker(Registry registry, ThreadPoolExecutor executor) {
+    PolledMeter.using(registry)
+        .withName("threadpool.completedTasks")
+        .monitorMonotonicCounter(executor, ThreadPoolExecutor::getCompletedTaskCount);
+  }
+}
+```
+
+For double-valued sources, use `monitorMonotonicCounterDouble`. A minimum of two polls is
+required before the first metric is reported.
+
+Java is long-based, so there is no separate uint64 variant — `monitorMonotonicCounter` covers
+both signed and OS-counter use cases.

--- a/docs/spectator/lang/java/meters/percentile-dist-summary.md
+++ b/docs/spectator/lang/java/meters/percentile-dist-summary.md
@@ -1,0 +1,30 @@
+# Percentile Distribution Summary
+
+See [Percentile Distribution Summary](../../../patterns/percentile-dist-summary.md) for the
+concept and storage-cost caveats. Use a regular [Distribution Summary](dist-summary.md) unless
+percentile estimates are required.
+
+Create one via the static builder:
+
+```java
+public class Server {
+
+  private final PercentileDistributionSummary requestSize;
+
+  @Inject
+  public Server(Registry registry) {
+    requestSize = PercentileDistributionSummary.builder(registry)
+        .withId(registry.createId("server.request.size"))
+        .build();
+  }
+
+  public void onRequest(Request request) {
+    requestSize.record(request.bodyBytes());
+  }
+}
+```
+
+The builder also accepts a range via `withRange(min, max)` to bound the bucket set and reduce
+storage overhead — see the
+[Javadoc](https://static.javadoc.io/com.netflix.spectator/spectator-api/latest/com/netflix/spectator/api/histogram/PercentileDistributionSummary.html)
+for details.

--- a/docs/spectator/lang/nodejs/meters/age-gauge.md
+++ b/docs/spectator/lang/nodejs/meters/age-gauge.md
@@ -1,5 +1,7 @@
 # Age Gauge
 
+See [Age Gauge](../../../patterns/age-gauge.md) for the concept.
+
 The value is the time in seconds since the epoch at which an event has successfully occurred, or
 `0` to use the current time in epoch seconds. After an Age Gauge has been set, it will continue
 reporting the number of seconds since the last time recorded, for as long as the SpectatorD

--- a/docs/spectator/lang/nodejs/meters/max-gauge.md
+++ b/docs/spectator/lang/nodejs/meters/max-gauge.md
@@ -1,5 +1,7 @@
 # Max Gauge
 
+See [Max Gauge](../../../core/meters/max-gauge.md) for the concept.
+
 The value is a number that is sampled at a point in time, but it is reported as a maximum Gauge
 value to the backend. This ensures that only the maximum value observed during a reporting interval
 is sent to the backend, thus over-riding the last-write-wins semantics of standard Gauges. Unlike

--- a/docs/spectator/lang/nodejs/meters/monotonic-counter-uint.md
+++ b/docs/spectator/lang/nodejs/meters/monotonic-counter-uint.md
@@ -1,5 +1,7 @@
 # Monotonic Counter (uint64)
 
+See [Monotonic Counter](../../../patterns/monotonic-counter.md) for the concept (uint64 variant).
+
 A Monotonic Counter (uint64) is used to measure the rate at which an event is occurring, when the
 source data is a monotonically increasing number. A minimum of two samples must be sent, in order to
 calculate a delta value and report it to the backend as a rate-per-second. A variety of networking

--- a/docs/spectator/lang/nodejs/meters/monotonic-counter.md
+++ b/docs/spectator/lang/nodejs/meters/monotonic-counter.md
@@ -1,5 +1,7 @@
 # Monotonic Counter
 
+See [Monotonic Counter](../../../patterns/monotonic-counter.md) for the concept.
+
 A Monotonic Counter (float) is used to measure the rate at which an event is occurring, when the
 source data is a monotonically increasing number. A minimum of two samples must be sent, in order to
 calculate a delta value and report it to the backend as a rate-per-second. A variety of networking

--- a/docs/spectator/lang/nodejs/meters/percentile-dist-summary.md
+++ b/docs/spectator/lang/nodejs/meters/percentile-dist-summary.md
@@ -1,5 +1,7 @@
 # Percentile Distribution Summary
 
+See [Percentile Distribution Summary](../../../patterns/percentile-dist-summary.md) for the concept.
+
 The value tracks the distribution of events, with percentile estimates. It is similar to a
 `PercentileTimer`, but more general, because the size does not have to be a period of time.
 

--- a/docs/spectator/lang/py/meters/age-gauge.md
+++ b/docs/spectator/lang/py/meters/age-gauge.md
@@ -1,5 +1,7 @@
 # Age Gauge
 
+See [Age Gauge](../../../patterns/age-gauge.md) for the concept.
+
 The value is the time in seconds since the epoch at which an event has successfully occurred, or
 `0` to use the current time in epoch seconds. After an Age Gauge has been set, it will continue
 reporting the number of seconds since the last time recorded, for as long as the SpectatorD

--- a/docs/spectator/lang/py/meters/max-gauge.md
+++ b/docs/spectator/lang/py/meters/max-gauge.md
@@ -1,5 +1,7 @@
 # Max Gauge
 
+See [Max Gauge](../../../core/meters/max-gauge.md) for the concept.
+
 The value is a number that is sampled at a point in time, but it is reported as a maximum Gauge
 value to the backend. This ensures that only the maximum value observed during a reporting interval
 is sent to the backend, thus over-riding the last-write-wins semantics of standard Gauges. Unlike

--- a/docs/spectator/lang/py/meters/monotonic-counter-uint.md
+++ b/docs/spectator/lang/py/meters/monotonic-counter-uint.md
@@ -1,5 +1,7 @@
 # Monotonic Counter (uint64)
 
+See [Monotonic Counter](../../../patterns/monotonic-counter.md) for the concept (uint64 variant).
+
 A Monotonic Counter (uint64) is used to measure the rate at which an event is occurring, when the
 source data is a monotonically increasing number. A minimum of two samples must be sent, in order to
 calculate a delta value and report it to the backend as a rate-per-second. A variety of networking

--- a/docs/spectator/lang/py/meters/monotonic-counter.md
+++ b/docs/spectator/lang/py/meters/monotonic-counter.md
@@ -1,5 +1,7 @@
 # Monotonic Counter
 
+See [Monotonic Counter](../../../patterns/monotonic-counter.md) for the concept.
+
 A Monotonic Counter (float) is used to measure the rate at which an event is occurring, when the
 source data is a monotonically increasing number. A minimum of two samples must be sent, in order to
 calculate a delta value and report it to the backend as a rate-per-second. A variety of networking

--- a/docs/spectator/lang/py/meters/percentile-dist-summary.md
+++ b/docs/spectator/lang/py/meters/percentile-dist-summary.md
@@ -1,5 +1,7 @@
 # Percentile Distribution Summary
 
+See [Percentile Distribution Summary](../../../patterns/percentile-dist-summary.md) for the concept.
+
 The value tracks the distribution of events, with percentile estimates. It is similar to a
 `PercentileTimer`, but more general, because the size does not have to be a period of time.
 

--- a/docs/spectator/patterns/age-gauge.md
+++ b/docs/spectator/patterns/age-gauge.md
@@ -1,0 +1,43 @@
+# Age Gauge
+
+An Age Gauge reports the time in seconds since some event last occurred successfully.
+It is a use of a [Gauge](../core/meters/gauge.md) where the value reported is computed
+as `now - lastSuccessTimestamp` on each reporting interval.
+
+The primary use case is the **Time Since Last Success** alerting pattern: alert when a
+periodic job, heartbeat, or freshness signal stops advancing.
+
+## Implementations
+
+For the spectatord-backed clients (C++, Go, Node.js, Python), Age Gauge is exposed as a
+first-class meter type. The client records the last-success timestamp (or `now()`) and
+spectatord handles the elapsed-time calculation on each reporting interval, continuing to
+report for as long as the spectatord process runs.
+
+For Java, there is no dedicated Age Gauge meter. The equivalent is a polled gauge that
+computes the age on each poll — see [Polled Meter](polled-meter.md):
+
+```java
+AtomicLong lastSuccess = new AtomicLong(System.currentTimeMillis() / 1000);
+PolledMeter.using(registry)
+    .withName("time.sinceLastSuccess")
+    .monitorValue(lastSuccess, ts -> (System.currentTimeMillis() / 1000) - ts.get());
+
+// On successful event:
+lastSuccess.set(System.currentTimeMillis() / 1000);
+```
+
+## Lifecycle (spectatord-backed clients)
+
+Age Gauges are long-lived in the spectatord process — once set they continue reporting
+indefinitely. To prevent leaks, spectatord enforces a per-process limit (default `1000`,
+tunable via `--age_gauge_limit`). If you need to remove or replace one, use the
+[SpectatorD admin server](../agent/usage.md#admin-server).
+
+## Languages
+
+* [C++](../lang/cpp/meters/age-gauge.md)
+* [Go](../lang/go/meters/age-gauge.md)
+* [Java](../lang/java/meters/age-gauge.md) (no dedicated meter; uses [Polled Meter](polled-meter.md))
+* [Node.js](../lang/nodejs/meters/age-gauge.md)
+* [Python](../lang/py/meters/age-gauge.md)

--- a/docs/spectator/patterns/monotonic-counter.md
+++ b/docs/spectator/patterns/monotonic-counter.md
@@ -1,0 +1,47 @@
+# Monotonic Counter
+
+A Monotonic Counter is a use of a [Counter](../core/meters/counter.md) where the source
+data is a **cumulative** value that only increases (e.g. bytes-sent on a network interface,
+total tasks completed by a thread pool). The library samples successive absolute values and
+computes the delta itself, reporting the per-second rate to the backend.
+
+Use this when the underlying source is naturally monotonic and you don't have a hook to
+increment a regular counter on each event. Common sources: OS counters, JMX counters, thread
+pool stats, network interface counters.
+
+A minimum of **two samples** is required before the first metric is reported, so there is a
+slower time-to-first-data point than a standard counter.
+
+## Numeric variants
+
+* **Signed / double** — the default. Suitable when the source fits in a signed 64-bit
+  integer or double and is not expected to overflow.
+* **uint64** — required when reading from a source that uses unsigned 64-bit semantics
+  (most OS-level interface counters) so that a wrap-around past `2^63` is not interpreted
+  as a backward jump.
+
+The spectatord-backed clients (C++, Go, Node.js, Python) expose both variants. In Java,
+use [Polled Meter](polled-meter.md)'s `monitorMonotonicCounter` — Java is long-based and
+does not need a separate uint variant.
+
+## Implementations
+
+For the spectatord-backed clients, Monotonic Counter is a first-class meter type — call
+`set(absoluteValue)` on each sample.
+
+For Java, the equivalent is exposed via the [Polled Meter](polled-meter.md) helper, which
+periodically samples a function returning the current absolute value and reports the delta:
+
+```java
+PolledMeter.using(registry)
+    .withName("threadpool.completedTasks")
+    .monitorMonotonicCounter(executor, ThreadPoolExecutor::getCompletedTaskCount);
+```
+
+## Languages
+
+* C++: [signed](../lang/cpp/meters/monotonic-counter.md), [uint64](../lang/cpp/meters/monotonic-counter-uint.md)
+* Go: [signed](../lang/go/meters/monotonic-counter.md), [uint64](../lang/go/meters/monotonic-counter-uint.md)
+* [Java](../lang/java/meters/monotonic-counter.md) (no dedicated meter; uses [Polled Meter](polled-meter.md))
+* Node.js: [signed](../lang/nodejs/meters/monotonic-counter.md), [uint64](../lang/nodejs/meters/monotonic-counter-uint.md)
+* Python: [signed](../lang/py/meters/monotonic-counter.md), [uint64](../lang/py/meters/monotonic-counter-uint.md)

--- a/docs/spectator/patterns/percentile-dist-summary.md
+++ b/docs/spectator/patterns/percentile-dist-summary.md
@@ -1,0 +1,29 @@
+# Percentile Distribution Summary
+
+A Percentile Distribution Summary tracks the distribution of events with percentile
+estimates. It is the size-domain analog of a [Percentile Timer](percentile-timer.md):
+where Percentile Timer is for durations, Percentile Distribution Summary is for arbitrary
+sizes — request payload sizes, records returned from a query, batch sizes, etc.
+
+The summary maintains a set of bucket Counters that the backend uses to estimate percentiles
+while still allowing slicing by dimensions.
+
+!!! Warning
+    Percentile Distribution Summaries have significantly higher storage cost than a standard
+    [Distribution Summary](../core/meters/dist-summary.md) — worst case up to 300x. Use them
+    sparingly, and keep tag cardinality tightly bounded. Prefer a standard Distribution
+    Summary unless percentile estimates are required.
+
+## Bucket Distribution
+
+Uses the same power-of-4 bucket scheme as [Percentile Timer](percentile-timer.md#bucket-distribution).
+
+## Languages
+
+### First-Class Support
+
+* [C++](../lang/cpp/meters/percentile-dist-summary.md)
+* [Go](../lang/go/meters/percentile-dist-summary.md)
+* [Java](../lang/java/meters/percentile-dist-summary.md)
+* [Node.js](../lang/nodejs/meters/percentile-dist-summary.md)
+* [Python](../lang/py/meters/percentile-dist-summary.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -226,6 +226,7 @@ nav:
       - Counter: spectator/core/meters/counter.md
       - Distribution Summary: spectator/core/meters/dist-summary.md
       - Gauge: spectator/core/meters/gauge.md
+      - Max Gauge: spectator/core/meters/max-gauge.md
       - Timer: spectator/core/meters/timer.md
   - Languages:
     - Overview: spectator/lang/overview.md
@@ -264,9 +265,13 @@ nav:
       - Registry:
         - Overview: spectator/lang/java/registry/overview.md
       - Meters:
+        - Age Gauge: spectator/lang/java/meters/age-gauge.md
         - Counter: spectator/lang/java/meters/counter.md
         - Distribution Summary: spectator/lang/java/meters/dist-summary.md
         - Gauge: spectator/lang/java/meters/gauge.md
+        - Max Gauge: spectator/lang/java/meters/max-gauge.md
+        - Monotonic Counter: spectator/lang/java/meters/monotonic-counter.md
+        - Percentile Distribution Summary: spectator/lang/java/meters/percentile-dist-summary.md
         - Percentile Timer: spectator/lang/java/meters/percentile-timer.md
         - Timer: spectator/lang/java/meters/timer.md
       - Patterns:
@@ -319,8 +324,11 @@ nav:
       - Migrations: spectator/lang/py/migrations.md
       - Performance: spectator/lang/py/perf-test.md
   - Patterns:
+    - Age Gauge: spectator/patterns/age-gauge.md
     - Cardinality Limiter: spectator/patterns/cardinality-limiter.md
     - Long Task Timer: spectator/patterns/long-task-timer.md
+    - Monotonic Counter: spectator/patterns/monotonic-counter.md
+    - Percentile Distribution Summary: spectator/patterns/percentile-dist-summary.md
     - Percentile Timer: spectator/patterns/percentile-timer.md
     - Polled Meter: spectator/patterns/polled-meter.md
   - Specifications:


### PR DESCRIPTION
Adds language-agnostic concept and pattern pages so meter types that were only documented per-language now have a single source of truth:

- core/meters/max-gauge.md (true distinct meter type — different aggregation semantics from a standard Gauge).
- patterns/percentile-dist-summary.md (size-domain analog of Percentile Timer; kept alongside it in the Patterns section for consistency).
- patterns/age-gauge.md and patterns/monotonic-counter.md (these are really uses of Gauge/Counter; spectatord-backed clients expose them natively, Java implements them via PolledMeter).

Adds matching Java meter pages so the per-language structure is symmetric: max-gauge, percentile-dist-summary, age-gauge, monotonic- counter. Java is long-based so no separate uint64 monotonic variant is needed.

Wires per-language meter pages with backlinks to the new concept/ pattern pages so navigation works both directions.