### PR TITLE
clean up age-gauge / monotonic-counter pattern pages

### DIFF
--- a/docs/spectator/lang/java/meters/age-gauge.md
+++ b/docs/spectator/lang/java/meters/age-gauge.md
@@ -2,8 +2,10 @@
 
 See [Age Gauge](../../../patterns/age-gauge.md) for the concept.
 
-Java does not have a dedicated Age Gauge meter. The equivalent is a [Polled Meter](../../../patterns/polled-meter.md)
-that computes `now - lastSuccessTimestamp` on each poll:
+Java does not have a dedicated Age Gauge meter. Use a [Polled Meter](../../../patterns/polled-meter.md)
+together with the [`Functions.AGE`](https://www.javadoc.io/static/com.netflix.spectator/spectator-api/latest/com/netflix/spectator/api/Functions.html#AGE)
+helper, which computes the age in seconds from a wall-time millis timestamp stored in an
+`AtomicLong`:
 
 ```java
 public class Job {
@@ -14,16 +16,26 @@ public class Job {
   public Job(Registry registry) {
     lastSuccess = PolledMeter.using(registry)
         .withName("job.timeSinceLastSuccess")
-        .monitorValue(
-            new AtomicLong(registry.clock().wallTime() / 1000),
-            ts -> (registry.clock().wallTime() / 1000) - ts.get());
+        .monitorValue(new AtomicLong(System.currentTimeMillis()), Functions.AGE);
   }
 
   public void onSuccess() {
-    lastSuccess.set(registry.clock().wallTime() / 1000);
+    lastSuccess.set(System.currentTimeMillis());
   }
 }
 ```
 
 This reports the seconds elapsed since the last successful run, which is the basis for the
 Time Since Last Success alerting pattern.
+
+For tests that need to control time, use [`Functions.age(Clock)`](https://www.javadoc.io/static/com.netflix.spectator/spectator-api/latest/com/netflix/spectator/api/Functions.html#age-com.netflix.spectator.api.Clock-)
+with a `ManualClock` (typically the same clock used by the test `Registry`):
+
+```java
+ManualClock clock = new ManualClock();
+Registry registry = new DefaultRegistry(clock);
+
+PolledMeter.using(registry)
+    .withName("job.timeSinceLastSuccess")
+    .monitorValue(new AtomicLong(clock.wallTime()), Functions.age(clock));
+```

--- a/docs/spectator/patterns/age-gauge.md
+++ b/docs/spectator/patterns/age-gauge.md
@@ -7,37 +7,18 @@ as `now - lastSuccessTimestamp` on each reporting interval.
 The primary use case is the **Time Since Last Success** alerting pattern: alert when a
 periodic job, heartbeat, or freshness signal stops advancing.
 
-## Implementations
+## Lifecycle
 
-For the spectatord-backed clients (C++, Go, Node.js, Python), Age Gauge is exposed as a
-first-class meter type. The client records the last-success timestamp (or `now()`) and
-spectatord handles the elapsed-time calculation on each reporting interval, continuing to
-report for as long as the spectatord process runs.
-
-For Java, there is no dedicated Age Gauge meter. The equivalent is a polled gauge that
-computes the age on each poll — see [Polled Meter](polled-meter.md):
-
-```java
-AtomicLong lastSuccess = new AtomicLong(System.currentTimeMillis() / 1000);
-PolledMeter.using(registry)
-    .withName("time.sinceLastSuccess")
-    .monitorValue(lastSuccess, ts -> (System.currentTimeMillis() / 1000) - ts.get());
-
-// On successful event:
-lastSuccess.set(System.currentTimeMillis() / 1000);
-```
-
-## Lifecycle (spectatord-backed clients)
-
-Age Gauges are long-lived in the spectatord process — once set they continue reporting
-indefinitely. To prevent leaks, spectatord enforces a per-process limit (default `1000`,
-tunable via `--age_gauge_limit`). If you need to remove or replace one, use the
+Age Gauges are long-lived — once set they continue reporting indefinitely until the
+process is restarted or the gauge is explicitly removed. For spectatord-backed clients,
+spectatord enforces a per-process limit (default `1000`, tunable via `--age_gauge_limit`)
+to prevent leaks. To remove or replace one, use the
 [SpectatorD admin server](../agent/usage.md#admin-server).
 
 ## Languages
 
 * [C++](../lang/cpp/meters/age-gauge.md)
 * [Go](../lang/go/meters/age-gauge.md)
-* [Java](../lang/java/meters/age-gauge.md) (no dedicated meter; uses [Polled Meter](polled-meter.md))
+* [Java](../lang/java/meters/age-gauge.md)
 * [Node.js](../lang/nodejs/meters/age-gauge.md)
 * [Python](../lang/py/meters/age-gauge.md)

--- a/docs/spectator/patterns/monotonic-counter.md
+++ b/docs/spectator/patterns/monotonic-counter.md
@@ -20,28 +20,12 @@ slower time-to-first-data point than a standard counter.
   (most OS-level interface counters) so that a wrap-around past `2^63` is not interpreted
   as a backward jump.
 
-The spectatord-backed clients (C++, Go, Node.js, Python) expose both variants. In Java,
-use [Polled Meter](polled-meter.md)'s `monitorMonotonicCounter` — Java is long-based and
-does not need a separate uint variant.
-
-## Implementations
-
-For the spectatord-backed clients, Monotonic Counter is a first-class meter type — call
-`set(absoluteValue)` on each sample.
-
-For Java, the equivalent is exposed via the [Polled Meter](polled-meter.md) helper, which
-periodically samples a function returning the current absolute value and reports the delta:
-
-```java
-PolledMeter.using(registry)
-    .withName("threadpool.completedTasks")
-    .monitorMonotonicCounter(executor, ThreadPoolExecutor::getCompletedTaskCount);
-```
+Java is long-based and does not need a separate uint variant.
 
 ## Languages
 
 * C++: [signed](../lang/cpp/meters/monotonic-counter.md), [uint64](../lang/cpp/meters/monotonic-counter-uint.md)
 * Go: [signed](../lang/go/meters/monotonic-counter.md), [uint64](../lang/go/meters/monotonic-counter-uint.md)
-* [Java](../lang/java/meters/monotonic-counter.md) (no dedicated meter; uses [Polled Meter](polled-meter.md))
+* [Java](../lang/java/meters/monotonic-counter.md)
 * Node.js: [signed](../lang/nodejs/meters/monotonic-counter.md), [uint64](../lang/nodejs/meters/monotonic-counter-uint.md)
 * Python: [signed](../lang/py/meters/monotonic-counter.md), [uint64](../lang/py/meters/monotonic-counter-uint.md)


### PR DESCRIPTION
- Java age-gauge: use Functions.AGE (and Functions.age(Clock) for testable variants with ManualClock) instead of a manual lambda.
- Pattern pages: drop the inline Java code snippets and language- specific implementation prose. Readers can click through to the per-language pages for code. The pattern pages stay focused on the concept and cross-cutting notes (lifecycle, numeric variants).