### PR TITLE
docs cleanup: per-language syntax and API surface

### DIFF
--- a/docs/spectator/agent/usage.md
+++ b/docs/spectator/agent/usage.md
@@ -30,9 +30,13 @@ spectatord: A daemon that listens for metrics and reports them to Atlas.
     --debug (Debug spectatord. All values will be sent to a dev aggregator and
       dropped.); default: false;
     --enable_external (Enable external publishing.); default: false;
+    --enable_insight_logs (Send internal logs to the Insight Logs agent on
+      localhost:1552.); default: true;
     --enable_socket (Enable UNIX domain socket support. Default is true on Linux
       and false on MacOS and Windows.); default: false;
     --enable_statsd (Enable statsd support.); default: false;
+    --frequency (Reporting frequency: how often metrics are flushed to the Atlas
+      aggregator.); default: 5s;
     --ipv4_only (Enable IPv4-only UDP listeners. This option should only be used
       in environments where it is impossible to run IPv6.); default: false;
     --metatron_dir (Path to the Metatron certificates, which are used for

--- a/docs/spectator/lang/nodejs/usage.md
+++ b/docs/spectator/lang/nodejs/usage.md
@@ -239,24 +239,29 @@ process.on("SIGTERM", shutdown);
 
 Save this snippet as `app.js`, then `node app.js`.
 
-## Override Logger
+## Async Semantics
 
-You can override the logger used by the Spectator registry by setting the logger parameter in the
-`Config` object. The specified logger should provide `debug`, `info`, and `error` methods. By
-default, `spectator-js` logs to stdout.
+Meter update methods such as `Counter.increment()`, `Timer.record()`, and
+`DistributionSummary.record()` return a `Promise<void>` because the underlying writer
+sends to `spectatord` asynchronously.
+
+In most application code you do not need the result of these calls — fire-and-forget is
+the expected pattern. Prefix the call with `void` to make it explicit that the returned
+Promise is intentionally ignored:
 
 ```javascript
-const logger = require('pino')();
-const spectator = require("nflx-spectator");
-const config = new spectator.Config("udp", {}, logger);
-const registry = new spectator.Registry(config);
+void registry.counter("server.numRequests").increment();
 ```
 
-## Runtime Metrics
+In **high-volume tight loops**, you should `await` the promise instead. Failing to do so
+will accumulate unresolved promises and can lead to heap exhaustion — see the
+[Performance](#performance) section.
 
-Use [spectator-js-nodejsmetrics](https://github.com/Netflix-Skunkworks/spectator-js-nodejsmetrics).
-
-The [Instrumenting Code](#complex-example) examples show how to use this library.
+```javascript
+for (const item of batch) {
+    await registry.counter("batch.itemProcessed").increment();
+}
+```
 
 ## Working with Id Objects
 
@@ -276,9 +281,9 @@ validate these values, dropping or changing any that are not valid, and reportin
 import {Registry} from "nflx-spectator";
 
 const registry = new Registry();
-void registry.counter("server.numRequests", {"statusCode": str(200)}).increment();
+void registry.counter("server.numRequests", {"statusCode": String(200)}).increment();
 
-const num_requests_id = registry.new_id("server.numRequests", {"statusCode": str(200)});
+const num_requests_id = registry.new_id("server.numRequests", {"statusCode": String(200)});
 void registry.counter_with_id(num_requests_id).increment();
 ```
 
@@ -287,6 +292,25 @@ be chosen thoughtfully, while considering how they will be used. See the [naming
 for general guidelines on metrics naming and restrictions.
 
 [naming conventions]: ../../../concepts/naming.md
+
+## Override Logger
+
+You can override the logger used by the Spectator registry by setting the logger parameter in the
+`Config` object. The specified logger should provide `debug`, `info`, and `error` methods. By
+default, `spectator-js` logs to stdout.
+
+```javascript
+const logger = require('pino')();
+const spectator = require("nflx-spectator");
+const config = new spectator.Config("udp", {}, logger);
+const registry = new spectator.Registry(config);
+```
+
+## Runtime Metrics
+
+Use [spectator-js-nodejsmetrics](https://github.com/Netflix-Skunkworks/spectator-js-nodejsmetrics).
+
+The [Instrumenting Code](#complex-example) examples show how to use this library.
 
 ## Meter Types
 

--- a/docs/spectator/lang/py/usage.md
+++ b/docs/spectator/lang/py/usage.md
@@ -126,6 +126,37 @@ registry = Registry()
 registry.counter("server.requestCount").increment()
 ```
 
+### Working with MeterId Objects
+
+Each metric stored in Atlas is uniquely identified by the combination of the name and the tags
+associated with it. In `spectator-py`, this data is represented with `MeterId` objects, created
+by the `Registry`. The `new_id()` method returns new `MeterId` objects, which have extra common
+tags applied, and which can be further customized by calling the `with_tag()` and `with_tags()`
+methods. Each `MeterId` will create and store a validated subset of the `spectatord` protocol line
+to be written for each `Meter`, when it is instantiated. `MeterId` objects are immutable, so they
+can be freely passed around and used concurrently. Manipulating the tags with the provided methods
+will create new `MeterId` objects, to assist with maintaining immutability.
+
+Note that **all tag keys and values must be strings.** For example, if you want to keep track of the
+number of successful requests, then you must cast integers to strings. The `MeterId` class will
+validate these values, dropping or changing any that are not valid, and reporting a warning log.
+
+```python
+from spectator import Registry
+
+registry = Registry()
+registry.counter("server.numRequests", {"statusCode": str(200)}).increment()
+
+num_requests_id = registry.new_id("server.numRequests", {"statusCode": str(200)})
+registry.counter_with_id(num_requests_id).increment()
+```
+
+Atlas metrics will be consumed by users many times after the data has been reported, so they should
+be chosen thoughtfully, while considering how they will be used. See the [naming conventions] page
+for general guidelines on metrics naming and restrictions.
+
+[naming conventions]: ../../../concepts/naming.md
+
 ### Legacy Usage
 
 The `GlobalRegistry` concept is a hold-over from the thick-client version of this library, but it
@@ -185,37 +216,6 @@ if __name__ == "__main__":
 ```
 
 [spectator-py-runtime-metrics]: https://github.com/Netflix/spectator-py-runtime-metrics
-
-## Working with MeterId Objects
-
-Each metric stored in Atlas is uniquely identified by the combination of the name and the tags
-associated with it. In `spectator-py`, this data is represented with `MeterId` objects, created
-by the `Registry`. The `new_id()` method returns new `MeterId` objects, which have extra common
-tags applied, and which can be further customized by calling the `with_tag()` and `with_tags()`
-methods. Each `MeterId` will create and store a validated subset of the `spectatord` protocol line
-to be written for each `Meter`, when it is instantiated. `MeterId` objects are immutable, so they
-can be freely passed around and used concurrently. Manipulating the tags with the provided methods
-will create new `MeterId` objects, to assist with maintaining immutability.
-
-Note that **all tag keys and values must be strings.** For example, if you want to keep track of the
-number of successful requests, then you must cast integers to strings. The `MeterId` class will
-validate these values, dropping or changing any that are not valid, and reporting a warning log.
-
-```python
-from spectator import Registry
-
-registry = Registry()
-registry.counter("server.numRequests", {"statusCode": str(200)}).increment()
-
-num_requests_id = registry.new_id("server.numRequests", {"statusCode": str(200)})
-registry.counter_with_id(num_requests_id).increment()
-```
-
-Atlas metrics will be consumed by users many times after the data has been reported, so they should
-be chosen thoughtfully, while considering how they will be used. See the [naming conventions] page
-for general guidelines on metrics naming and restrictions.
-
-[naming conventions]: ../../../concepts/naming.md
 
 ## Meter Types
 


### PR DESCRIPTION
- spectator-js (Node.js): add an "Async Semantics" section to usage.md explaining that meter update calls return Promise<void>. Most code should use the fire-and-forget "void registry.counter(...)" idiom; high-volume loops need "await" to avoid heap exhaustion. The examples consistently used "void" without explanation, and the perf section noted heap-fail without await but never connected the dots.
- spectator-js: promote "Working with Id Objects" up to right after the examples instead of buried two-thirds down the page. Also fix a copy/paste bug: example was using str(200) (Python) instead of String(200).
- spectator-py: promote "Working with MeterId Objects" up into the Importing section (as a peer of Standard / Legacy Usage). Mirrors the Node.js change for cross-language consistency.
- agent/usage.md: --help output was missing --enable_insight_logs (added with a default of true; sends internal logs to localhost:1552) and --frequency (5s default, controls how often metrics flush to Atlas). Both flags exist in the spectatord binary today.