### PR TITLE
add Runtime Metrics signpost to java/usage.md

### DIFF
--- a/docs/spectator/lang/java/usage.md
+++ b/docs/spectator/lang/java/usage.md
@@ -105,6 +105,17 @@ public class Server {
 }
 ```
 
+## Runtime Metrics
+
+JVM runtime metrics (GC, memory pools, buffer pools, threads, class loading, compilation,
+safepoints) are available via the `spectator-ext-*` extension libraries. See the JVM Stats
+pages under [Extensions](ext/jvm-gc.md) for the metrics each one exposes and the dependency
+to add.
+
+For applications that want everything wired up by default, the Netflix
+[SBN starter](#sbn-applications) registers these by default — see the
+[Netflix Integration](#netflix-integration) section below.
+
 ## Netflix Integration
 
 When running at Netflix, use the `atlas-client` library to enable transferring the


### PR DESCRIPTION
Cross-language audit: every spectatord-backed language has a "Runtime Metrics" section in its usage.md pointing at the right helper library (spectator-go-runtime-metrics, spectator-js-nodejsmetrics, spectator-py- runtime-metrics). Java's JVM ext libraries provide the equivalent but were only discoverable via the nav sidebar.

Add a brief "Runtime Metrics" section to java/usage.md that points at the Extensions > JVM Stats pages and notes that the SBN starter wires them up by default. No new content for the ext pages themselves -- this is purely a navigability fix so the Java page lists runtime metrics in the same place readers expect to find them in the other languages.

C++ has no equivalent runtime-metrics library, so no signpost is added there.