### PR TITLE
strip duplicated concept prose from per-language meter pages

### DIFF
--- a/docs/spectator/lang/cpp/meters/age-gauge.md
+++ b/docs/spectator/lang/cpp/meters/age-gauge.md
@@ -2,12 +2,6 @@
 
 See [Age Gauge](../../../patterns/age-gauge.md) for the concept.
 
-The value is the time in seconds since the epoch at which an event has successfully occurred, or
-`0` to use the current time in epoch seconds. After an Age Gauge has been set, it will continue
-reporting the number of seconds since the last time recorded, for as long as the SpectatorD
-process runs. The purpose of this metric type is to enable users to more easily implement the
-Time Since Last Success alerting pattern.
-
 To set a specific time as the last success:
 
 ```cpp
@@ -48,24 +42,3 @@ int main()
 }
 ```
 
-By default, a maximum of `1000` Age Gauges are allowed per `spectatord` process, because there is no
-mechanism for cleaning them up. This value may be tuned with the `--age_gauge_limit` flag on the
-`spectatord` binary.
-
-Since Age Gauges are long-lived entities that reside in the memory of the SpectatorD process, if
-you need to delete and re-create them for any reason, then you can use the [SpectatorD admin server]
-to accomplish this task. You can delete all Age Gauges or a single Age Gauge.
-
-**Example:**
-
-```
-curl -X DELETE \
-http://localhost:1234/metrics/A
-```
-
-```
-curl -X DELETE \
-http://localhost:1234/metrics/A/fooIsTheName,some.tag=val1,some.otherTag=val2
-```
-
-[SpectatorD admin server]: ../../../agent/usage.md#admin-server

--- a/docs/spectator/lang/cpp/meters/counter.md
+++ b/docs/spectator/lang/cpp/meters/counter.md
@@ -1,10 +1,6 @@
 # Counter
 
-A Counter is used to measure the rate at which an event is occurring. Considering an API endpoint,
-a Counter could be used to measure the rate at which it is being accessed.
-
-Counters are reported to the backend as a rate-per-second. In Atlas, the `:per-step` operator can
-be used to convert them back into a value-per-step on a graph.
+See [Counter](../../../core/meters/counter.md) for the concept.
 
 Call `Increment()` when an event occurs:
 

--- a/docs/spectator/lang/cpp/meters/dist-summary.md
+++ b/docs/spectator/lang/cpp/meters/dist-summary.md
@@ -1,14 +1,6 @@
 # Distribution Summary
 
-A Distribution Summary is used to track the distribution of events. It is similar to a Timer, but
-more general, in that the size does not have to be a period of time. For example, a Distribution
-Summary could be used to measure the payload sizes of requests hitting a server. Note that the C++
-implementation of Distribution Summary allows for the recording of floating point values, which the
-other thin clients do not allow.
-
-Always use base units when recording data, to ensure that the tick labels presented on Atlas graphs
-are readable. If you are measuring payload size, then use bytes, not kilobytes (or some other unit).
-This means that a `4K` tick label will represent 4 kilobytes, rather than 4 kilo-kilobytes.
+See [Distribution Summary](../../../core/meters/dist-summary.md) for the concept.
 
 Call `Record()` with a value:
 

--- a/docs/spectator/lang/cpp/meters/gauge.md
+++ b/docs/spectator/lang/cpp/meters/gauge.md
@@ -1,12 +1,6 @@
 # Gauge
 
-A gauge is a value that is sampled at some point in time. Typical examples for gauges would be
-the size of a queue or number of threads in a running state. Since gauges are not updated inline
-when a state change occurs, there is no information about what might have occurred between samples.
-
-Consider monitoring the behavior of a queue of tasks. If the data is being collected once a minute,
-then a gauge for the size will show the size when it was sampled. The size may have been much
-higher or lower at some point during interval, but that is not known.
+See [Gauge](../../../core/meters/gauge.md) for the concept.
 
 Call `Set()` with a value:
 

--- a/docs/spectator/lang/cpp/meters/max-gauge.md
+++ b/docs/spectator/lang/cpp/meters/max-gauge.md
@@ -2,11 +2,6 @@
 
 See [Max Gauge](../../../core/meters/max-gauge.md) for the concept.
 
-The value is a number that is sampled at a point in time, but it is reported as a maximum Gauge
-value to the backend. This ensures that only the maximum value observed during a reporting interval
-is sent to the backend, thus over-riding the last-write-wins semantics of standard Gauges. Unlike
-standard Gauges, Max Gauges do not continue to report to the backend, and there is no TTL.
-
 Call `Set()` with a value:
 
 ```cpp

--- a/docs/spectator/lang/cpp/meters/monotonic-counter-uint.md
+++ b/docs/spectator/lang/cpp/meters/monotonic-counter-uint.md
@@ -2,12 +2,6 @@
 
 See [Monotonic Counter](../../../patterns/monotonic-counter.md) for the concept (uint64 variant).
 
-A Monotonic Counter (uint64) is used to measure the rate at which an event is occurring, when the
-source data is a monotonically increasing number. A minimum of two samples must be sent, in order to
-calculate a delta value and report it to the backend as a rate-per-second. A variety of networking
-metrics may be reported monotonically, and this metric type provides a convenient means of recording
-these values, at the expense of a slower time-to-first metric.
-
 Call `Set()` when an event occurs:
 
 ```cpp

--- a/docs/spectator/lang/cpp/meters/monotonic-counter.md
+++ b/docs/spectator/lang/cpp/meters/monotonic-counter.md
@@ -2,12 +2,6 @@
 
 See [Monotonic Counter](../../../patterns/monotonic-counter.md) for the concept.
 
-A Monotonic Counter (float) is used to measure the rate at which an event is occurring, when the
-source data is a monotonically increasing number. A minimum of two samples must be sent, in order to
-calculate a delta value and report it to the backend as a rate-per-second. A variety of networking
-metrics may be reported monotonically, and this metric type provides a convenient means of recording
-these values, at the expense of a slower time-to-first metric.
-
 Call `Set()` when an event occurs:
 
 ```cpp

--- a/docs/spectator/lang/cpp/meters/percentile-dist-summary.md
+++ b/docs/spectator/lang/cpp/meters/percentile-dist-summary.md
@@ -2,18 +2,6 @@
 
 See [Percentile Distribution Summary](../../../patterns/percentile-dist-summary.md) for the concept.
 
-The value tracks the distribution of events, with percentile estimates. It is similar to a
-`PercentileTimer`, but more general, because the size does not have to be a period of time.
-
-For example, it can be used to measure the payload sizes of requests hitting a server or the
-number of records returned from a query. Note that the C++ implementation of Percentile Distribution
-Summary allows for the recording of floating point values, which the other thin clients do not
-allow.
-
-In order to maintain the data distribution, they have a higher storage cost, with a worst-case of
-up to 300X that of a standard Distribution Summary. Be diligent about any additional dimensions
-added to Percentile Distribution Summaries and ensure that they have a small bounded cardinality.
-
 Call `Record()` with a value:
 
 ```cpp

--- a/docs/spectator/lang/cpp/meters/percentile-timer.md
+++ b/docs/spectator/lang/cpp/meters/percentile-timer.md
@@ -1,14 +1,6 @@
 # Percentile Timer
 
-The value is the number of seconds that have elapsed for an event, with percentile estimates.
-
-This metric type will track the data distribution by maintaining a set of Counters. The
-distribution can then be used on the server side to estimate percentiles, while still
-allowing for arbitrary slicing and dicing based on dimensions.
-
-In order to maintain the data distribution, they have a higher storage cost, with a worst-case of
-up to 300X that of a standard Timer. Be diligent about any additional dimensions added to Percentile
-Timers and ensure that they have a small bounded cardinality.
+See [Percentile Timer](../../../patterns/percentile-timer.md) for the concept.
 
 Call `Record()` with a value:
 

--- a/docs/spectator/lang/cpp/meters/timer.md
+++ b/docs/spectator/lang/cpp/meters/timer.md
@@ -1,6 +1,6 @@
 # Timer
 
-A Timer is used to measure how long (in seconds) some event is taking.
+See [Timer](../../../core/meters/timer.md) for the concept.
 
 Call `Record()` with a value:
 

--- a/docs/spectator/lang/go/meters/age-gauge.md
+++ b/docs/spectator/lang/go/meters/age-gauge.md
@@ -2,12 +2,6 @@
 
 See [Age Gauge](../../../patterns/age-gauge.md) for the concept.
 
-The value is the time in seconds since the epoch at which an event has successfully occurred, or
-`0` to use the current time in epoch seconds. After an Age Gauge has been set, it will continue
-reporting the number of seconds since the last time recorded, for as long as the SpectatorD
-process runs. The purpose of this metric type is to enable users to more easily implement the
-Time Since Last Success alerting pattern.
-
 To `Set()` a specific time as the last success:
 
 ```golang
@@ -44,24 +38,3 @@ func main() {
 }
 ```
 
-By default, a maximum of `1000` Age Gauges are allowed per `spectatord` process, because there is no
-mechanism for cleaning them up. This value may be tuned with the `--age_gauge_limit` flag on the
-`spectatord` binary.
-
-Since Age Gauges are long-lived entities that reside in the memory of the SpectatorD process, if
-you need to delete and re-create them for any reason, then you can use the [SpectatorD admin server]
-to accomplish this task. You can delete all Age Gauges or a single Age Gauge.
-
-**Example:**
-
-```
-curl -X DELETE \
-http://localhost:1234/metrics/A
-```
-
-```
-curl -X DELETE \
-http://localhost:1234/metrics/A/fooIsTheName,some.tag=val1,some.otherTag=val2
-```
-
-[SpectatorD admin server]: ../../../agent/usage.md#admin-server

--- a/docs/spectator/lang/go/meters/counter.md
+++ b/docs/spectator/lang/go/meters/counter.md
@@ -1,10 +1,6 @@
 # Counter
 
-A Counter is used to measure the rate at which an event is occurring. Considering an API endpoint,
-a Counter could be used to measure the rate at which it is being accessed.
-
-Counters are reported to the backend as a rate-per-second. In Atlas, the `:per-step` operator can
-be used to convert them back into a value-per-step on a graph.
+See [Counter](../../../core/meters/counter.md) for the concept.
 
 Call `Increment()` when an event occurs:
 

--- a/docs/spectator/lang/go/meters/dist-summary.md
+++ b/docs/spectator/lang/go/meters/dist-summary.md
@@ -1,12 +1,6 @@
 # Distribution Summary
 
-A Distribution Summary is used to track the distribution of events. It is similar to a Timer, but
-more general, in that the size does not have to be a period of time. For example, a Distribution
-Summary could be used to measure the payload sizes of requests hitting a server.
-
-Always use base units when recording data, to ensure that the tick labels presented on Atlas graphs
-are readable. If you are measuring payload size, then use bytes, not kilobytes (or some other unit).
-This means that a `4K` tick label will represent 4 kilobytes, rather than 4 kilo-kilobytes.
+See [Distribution Summary](../../../core/meters/dist-summary.md) for the concept.
 
 Call `Record()` with a value:
 

--- a/docs/spectator/lang/go/meters/gauge.md
+++ b/docs/spectator/lang/go/meters/gauge.md
@@ -1,12 +1,6 @@
 # Gauge
 
-A gauge is a value that is sampled at some point in time. Typical examples for gauges would be
-the size of a queue or number of threads in a running state. Since gauges are not updated inline
-when a state change occurs, there is no information about what might have occurred between samples.
-
-Consider monitoring the behavior of a queue of tasks. If the data is being collected once a minute,
-then a gauge for the size will show the size when it was sampled. The size may have been much
-higher or lower at some point during interval, but that is not known.
+See [Gauge](../../../core/meters/gauge.md) for the concept.
 
 Call `Set()` with a value:
 

--- a/docs/spectator/lang/go/meters/max-gauge.md
+++ b/docs/spectator/lang/go/meters/max-gauge.md
@@ -2,11 +2,6 @@
 
 See [Max Gauge](../../../core/meters/max-gauge.md) for the concept.
 
-The value is a number that is sampled at a point in time, but it is reported as a maximum Gauge
-value to the backend. This ensures that only the maximum value observed during a reporting interval
-is sent to the backend, thus over-riding the last-write-wins semantics of standard Gauges. Unlike
-standard Gauges, Max Gauges do not continue to report to the backend, and there is no TTL.
-
 Call `Set()` with a value:
 
 ```golang

--- a/docs/spectator/lang/go/meters/monotonic-counter-uint.md
+++ b/docs/spectator/lang/go/meters/monotonic-counter-uint.md
@@ -2,12 +2,6 @@
 
 See [Monotonic Counter](../../../patterns/monotonic-counter.md) for the concept (uint64 variant).
 
-A Monotonic Counter (uint64) is used to measure the rate at which an event is occurring, when the
-source data is a monotonically increasing number. A minimum of two samples must be sent, in order to
-calculate a delta value and report it to the backend as a rate-per-second. A variety of networking
-metrics may be reported monotonically, and this metric type provides a convenient means of recording
-these values, at the expense of a slower time-to-first metric.
-
 Call `Set()` when an event occurs:
 
 ```golang

--- a/docs/spectator/lang/go/meters/monotonic-counter.md
+++ b/docs/spectator/lang/go/meters/monotonic-counter.md
@@ -2,12 +2,6 @@
 
 See [Monotonic Counter](../../../patterns/monotonic-counter.md) for the concept.
 
-A Monotonic Counter (float) is used to measure the rate at which an event is occurring, when the
-source data is a monotonically increasing number. A minimum of two samples must be sent, in order to
-calculate a delta value and report it to the backend as a rate-per-second. A variety of networking
-metrics may be reported monotonically, and this metric type provides a convenient means of recording
-these values, at the expense of a slower time-to-first metric.
-
 Call `Set()` when an event occurs:
 
 ```golang

--- a/docs/spectator/lang/go/meters/percentile-dist-summary.md
+++ b/docs/spectator/lang/go/meters/percentile-dist-summary.md
@@ -2,16 +2,6 @@
 
 See [Percentile Distribution Summary](../../../patterns/percentile-dist-summary.md) for the concept.
 
-The value tracks the distribution of events, with percentile estimates. It is similar to a
-`PercentileTimer`, but more general, because the size does not have to be a period of time.
-
-For example, it can be used to measure the payload sizes of requests hitting a server or the
-number of records returned from a query.
-
-In order to maintain the data distribution, they have a higher storage cost, with a worst-case of
-up to 300X that of a standard Distribution Summary. Be diligent about any additional dimensions
-added to Percentile Distribution Summaries and ensure that they have a small bounded cardinality.
-
 Call `Record()` with a value:
 
 ```golang

--- a/docs/spectator/lang/go/meters/percentile-timer.md
+++ b/docs/spectator/lang/go/meters/percentile-timer.md
@@ -1,14 +1,6 @@
 # Percentile Timer
 
-The value is the number of seconds that have elapsed for an event, with percentile estimates.
-
-This metric type will track the data distribution by maintaining a set of Counters. The
-distribution can then be used on the server side to estimate percentiles, while still
-allowing for arbitrary slicing and dicing based on dimensions.
-
-In order to maintain the data distribution, they have a higher storage cost, with a worst-case of
-up to 300X that of a standard Timer. Be diligent about any additional dimensions added to Percentile
-Timers and ensure that they have a small bounded cardinality.
+See [Percentile Timer](../../../patterns/percentile-timer.md) for the concept.
 
 Call `Record()` with a value:
 

--- a/docs/spectator/lang/go/meters/timer.md
+++ b/docs/spectator/lang/go/meters/timer.md
@@ -1,6 +1,6 @@
 # Timer
 
-A Timer is used to measure how long (in seconds) some event is taking.
+See [Timer](../../../core/meters/timer.md) for the concept.
 
 Call `record()` with a value:
 

--- a/docs/spectator/lang/java/meters/counter.md
+++ b/docs/spectator/lang/java/meters/counter.md
@@ -1,5 +1,7 @@
 # Counter
 
+See [Counter](../../../core/meters/counter.md) for the concept.
+
 Counters are created using the [Registry](../registry/overview.md), which is be setup as part of
 application initialization. For example:
 

--- a/docs/spectator/lang/java/meters/dist-summary.md
+++ b/docs/spectator/lang/java/meters/dist-summary.md
@@ -1,5 +1,7 @@
 # Distribution Summary
 
+See [Distribution Summary](../../../core/meters/dist-summary.md) for the concept.
+
 Distribution Summaries are created using the [Registry](../registry/overview.md), which will be
 setup as part of application initialization. For example:
 

--- a/docs/spectator/lang/java/meters/gauge.md
+++ b/docs/spectator/lang/java/meters/gauge.md
@@ -1,5 +1,7 @@
 # Gauge
 
+See [Gauge](../../../core/meters/gauge.md) for the concept.
+
 ## Polled Gauges
 
 The most common use of Gauges is by registering a hook with Spectator, so that it will poll the

--- a/docs/spectator/lang/java/meters/timer.md
+++ b/docs/spectator/lang/java/meters/timer.md
@@ -1,5 +1,7 @@
 # Timer
 
+See [Timer](../../../core/meters/timer.md) for the concept.
+
 To get started, create an instance using the [Registry](../registry/overview.md):
 
 ```java

--- a/docs/spectator/lang/nodejs/meters/age-gauge.md
+++ b/docs/spectator/lang/nodejs/meters/age-gauge.md
@@ -2,12 +2,6 @@
 
 See [Age Gauge](../../../patterns/age-gauge.md) for the concept.
 
-The value is the time in seconds since the epoch at which an event has successfully occurred, or
-`0` to use the current time in epoch seconds. After an Age Gauge has been set, it will continue
-reporting the number of seconds since the last time recorded, for as long as the SpectatorD
-process runs. The purpose of this metric type is to enable users to more easily implement the
-Time Since Last Success alerting pattern.
-
 To set a specific time as the last success:
 
 ```javascript
@@ -32,24 +26,3 @@ const last_success = registry.new_id("time.sinceLastSuccess");
 void registry.age_gauge_with_id(last_success).now();
 ```
 
-By default, a maximum of `1000` Age Gauges are allowed per `spectatord` process, because there is no
-mechanism for cleaning them up. This value may be tuned with the `--age_gauge_limit` flag on the
-`spectatord` binary.
-
-Since Age Gauges are long-lived entities that reside in the memory of the SpectatorD process, if
-you need to delete and re-create them for any reason, then you can use the [SpectatorD admin server]
-to accomplish this task. You can delete all Age Gauges or a single Age Gauge.
-
-**Example:**
-
-```
-curl -X DELETE \
-http://localhost:1234/metrics/A
-```
-
-```
-curl -X DELETE \
-http://localhost:1234/metrics/A/fooIsTheName,some.tag=val1,some.otherTag=val2
-```
-
-[SpectatorD admin server]: ../../../agent/usage.md#admin-server

--- a/docs/spectator/lang/nodejs/meters/counter.md
+++ b/docs/spectator/lang/nodejs/meters/counter.md
@@ -1,10 +1,6 @@
 # Counter
 
-A Counter is used to measure the rate at which an event is occurring. Considering an API endpoint,
-a Counter could be used to measure the rate at which it is being accessed.
-
-Counters are reported to the backend as a rate-per-second. In Atlas, the `:per-step` operator can
-be used to convert them back into a value-per-step on a graph.
+See [Counter](../../../core/meters/counter.md) for the concept.
 
 Call `increment()` when an event occurs:
 

--- a/docs/spectator/lang/nodejs/meters/dist-summary.md
+++ b/docs/spectator/lang/nodejs/meters/dist-summary.md
@@ -1,12 +1,6 @@
 # Distribution Summary
 
-A Distribution Summary is used to track the distribution of events. It is similar to a Timer, but
-more general, in that the size does not have to be a period of time. For example, a Distribution
-Summary could be used to measure the payload sizes of requests hitting a server.
-
-Always use base units when recording data, to ensure that the tick labels presented on Atlas graphs
-are readable. If you are measuring payload size, then use bytes, not kilobytes (or some other unit).
-This means that a `4K` tick label will represent 4 kilobytes, rather than 4 kilo-kilobytes.
+See [Distribution Summary](../../../core/meters/dist-summary.md) for the concept.
 
 Call `record()` with a value:
 

--- a/docs/spectator/lang/nodejs/meters/gauge.md
+++ b/docs/spectator/lang/nodejs/meters/gauge.md
@@ -1,12 +1,6 @@
 # Gauge
 
-A gauge is a value that is sampled at some point in time. Typical examples for gauges would be
-the size of a queue or number of threads in a running state. Since gauges are not updated inline
-when a state change occurs, there is no information about what might have occurred between samples.
-
-Consider monitoring the behavior of a queue of tasks. If the data is being collected once a minute,
-then a gauge for the size will show the size when it was sampled. The size may have been much
-higher or lower at some point during interval, but that is not known.
+See [Gauge](../../../core/meters/gauge.md) for the concept.
 
 Call `set()` with a value:
 

--- a/docs/spectator/lang/nodejs/meters/max-gauge.md
+++ b/docs/spectator/lang/nodejs/meters/max-gauge.md
@@ -2,11 +2,6 @@
 
 See [Max Gauge](../../../core/meters/max-gauge.md) for the concept.
 
-The value is a number that is sampled at a point in time, but it is reported as a maximum Gauge
-value to the backend. This ensures that only the maximum value observed during a reporting interval
-is sent to the backend, thus over-riding the last-write-wins semantics of standard Gauges. Unlike
-standard Gauges, Max Gauges do not continue to report to the backend, and there is no TTL.
-
 Call `set()` with a value:
 
 ```javascript

--- a/docs/spectator/lang/nodejs/meters/monotonic-counter-uint.md
+++ b/docs/spectator/lang/nodejs/meters/monotonic-counter-uint.md
@@ -2,12 +2,6 @@
 
 See [Monotonic Counter](../../../patterns/monotonic-counter.md) for the concept (uint64 variant).
 
-A Monotonic Counter (uint64) is used to measure the rate at which an event is occurring, when the
-source data is a monotonically increasing number. A minimum of two samples must be sent, in order to
-calculate a delta value and report it to the backend as a rate-per-second. A variety of networking
-metrics may be reported monotonically, and this metric type provides a convenient means of recording
-these values, at the expense of a slower time-to-first metric.
-
 Call `set()` when an event occurs:
 
 ```javascript

--- a/docs/spectator/lang/nodejs/meters/monotonic-counter.md
+++ b/docs/spectator/lang/nodejs/meters/monotonic-counter.md
@@ -2,12 +2,6 @@
 
 See [Monotonic Counter](../../../patterns/monotonic-counter.md) for the concept.
 
-A Monotonic Counter (float) is used to measure the rate at which an event is occurring, when the
-source data is a monotonically increasing number. A minimum of two samples must be sent, in order to
-calculate a delta value and report it to the backend as a rate-per-second. A variety of networking
-metrics may be reported monotonically, and this metric type provides a convenient means of recording
-these values, at the expense of a slower time-to-first metric.
-
 Call `set()` when an event occurs:
 
 ```javascript

--- a/docs/spectator/lang/nodejs/meters/percentile-dist-summary.md
+++ b/docs/spectator/lang/nodejs/meters/percentile-dist-summary.md
@@ -2,16 +2,6 @@
 
 See [Percentile Distribution Summary](../../../patterns/percentile-dist-summary.md) for the concept.
 
-The value tracks the distribution of events, with percentile estimates. It is similar to a
-`PercentileTimer`, but more general, because the size does not have to be a period of time.
-
-For example, it can be used to measure the payload sizes of requests hitting a server or the
-number of records returned from a query.
-
-In order to maintain the data distribution, they have a higher storage cost, with a worst-case of
-up to 300X that of a standard Distribution Summary. Be diligent about any additional dimensions
-added to Percentile Distribution Summaries and ensure that they have a small bounded cardinality.
-
 Call `record()` with a value:
 
 ```javascript

--- a/docs/spectator/lang/nodejs/meters/percentile-timer.md
+++ b/docs/spectator/lang/nodejs/meters/percentile-timer.md
@@ -1,14 +1,6 @@
 # Percentile Timer
 
-The value is the number of seconds that have elapsed for an event, with percentile estimates.
-
-This metric type will track the data distribution by maintaining a set of Counters. The
-distribution can then be used on the server side to estimate percentiles, while still
-allowing for arbitrary slicing and dicing based on dimensions.
-
-In order to maintain the data distribution, they have a higher storage cost, with a worst-case of
-up to 300X that of a standard Timer. Be diligent about any additional dimensions added to Percentile
-Timers and ensure that they have a small bounded cardinality.
+See [Percentile Timer](../../../patterns/percentile-timer.md) for the concept.
 
 Call `record()` with a value:
 

--- a/docs/spectator/lang/nodejs/meters/timer.md
+++ b/docs/spectator/lang/nodejs/meters/timer.md
@@ -1,6 +1,6 @@
 # Timer
 
-A Timer is used to measure how long (in seconds) some event is taking.
+See [Timer](../../../core/meters/timer.md) for the concept.
 
 Call `record()` with a value:
 

--- a/docs/spectator/lang/py/meters/age-gauge.md
+++ b/docs/spectator/lang/py/meters/age-gauge.md
@@ -2,12 +2,6 @@
 
 See [Age Gauge](../../../patterns/age-gauge.md) for the concept.
 
-The value is the time in seconds since the epoch at which an event has successfully occurred, or
-`0` to use the current time in epoch seconds. After an Age Gauge has been set, it will continue
-reporting the number of seconds since the last time recorded, for as long as the SpectatorD
-process runs. The purpose of this metric type is to enable users to more easily implement the
-Time Since Last Success alerting pattern.
-
 To set a specific time as the last success:
 
 ```python
@@ -32,24 +26,3 @@ last_success = registry.new_id("time.sinceLastSuccess")
 registry.age_gauge_with_id(last_success).now()
 ```
 
-By default, a maximum of `1000` Age Gauges are allowed per `spectatord` process, because there is no
-mechanism for cleaning them up. This value may be tuned with the `--age_gauge_limit` flag on the
-`spectatord` binary.
-
-Since Age Gauges are long-lived entities that reside in the memory of the SpectatorD process, if
-you need to delete and re-create them for any reason, then you can use the [SpectatorD admin server]
-to accomplish this task. You can delete all Age Gauges or a single Age Gauge.
-
-**Example:**
-
-```
-curl -X DELETE \
-http://localhost:1234/metrics/A
-```
-
-```
-curl -X DELETE \
-http://localhost:1234/metrics/A/fooIsTheName,some.tag=val1,some.otherTag=val2
-```
-
-[SpectatorD admin server]: ../../../agent/usage.md#admin-server

--- a/docs/spectator/lang/py/meters/counter.md
+++ b/docs/spectator/lang/py/meters/counter.md
@@ -1,10 +1,6 @@
 # Counter
 
-A Counter is used to measure the rate at which an event is occurring. Considering an API endpoint,
-a Counter could be used to measure the rate at which it is being accessed.
-
-Counters are reported to the backend as a rate-per-second. In Atlas, the `:per-step` operator can
-be used to convert them back into a value-per-step on a graph.
+See [Counter](../../../core/meters/counter.md) for the concept.
 
 Call `increment()` when an event occurs:
 

--- a/docs/spectator/lang/py/meters/dist-summary.md
+++ b/docs/spectator/lang/py/meters/dist-summary.md
@@ -1,12 +1,6 @@
 # Distribution Summary
 
-A Distribution Summary is used to track the distribution of events. It is similar to a Timer, but
-more general, in that the size does not have to be a period of time. For example, a Distribution
-Summary could be used to measure the payload sizes of requests hitting a server.
-
-Always use base units when recording data, to ensure that the tick labels presented on Atlas graphs
-are readable. If you are measuring payload size, then use bytes, not kilobytes (or some other unit).
-This means that a `4K` tick label will represent 4 kilobytes, rather than 4 kilo-kilobytes.
+See [Distribution Summary](../../../core/meters/dist-summary.md) for the concept.
 
 Call `record()` with a value:
 

--- a/docs/spectator/lang/py/meters/gauge.md
+++ b/docs/spectator/lang/py/meters/gauge.md
@@ -1,12 +1,6 @@
 # Gauge
 
-A gauge is a value that is sampled at some point in time. Typical examples for gauges would be
-the size of a queue or number of threads in a running state. Since gauges are not updated inline
-when a state change occurs, there is no information about what might have occurred between samples.
-
-Consider monitoring the behavior of a queue of tasks. If the data is being collected once a minute,
-then a gauge for the size will show the size when it was sampled. The size may have been much
-higher or lower at some point during interval, but that is not known.
+See [Gauge](../../../core/meters/gauge.md) for the concept.
 
 Call `set()` with a value:
 

--- a/docs/spectator/lang/py/meters/max-gauge.md
+++ b/docs/spectator/lang/py/meters/max-gauge.md
@@ -2,11 +2,6 @@
 
 See [Max Gauge](../../../core/meters/max-gauge.md) for the concept.
 
-The value is a number that is sampled at a point in time, but it is reported as a maximum Gauge
-value to the backend. This ensures that only the maximum value observed during a reporting interval
-is sent to the backend, thus over-riding the last-write-wins semantics of standard Gauges. Unlike
-standard Gauges, Max Gauges do not continue to report to the backend, and there is no TTL.
-
 Call `set()` with a value:
 
 ```python

--- a/docs/spectator/lang/py/meters/monotonic-counter-uint.md
+++ b/docs/spectator/lang/py/meters/monotonic-counter-uint.md
@@ -2,12 +2,6 @@
 
 See [Monotonic Counter](../../../patterns/monotonic-counter.md) for the concept (uint64 variant).
 
-A Monotonic Counter (uint64) is used to measure the rate at which an event is occurring, when the
-source data is a monotonically increasing number. A minimum of two samples must be sent, in order to
-calculate a delta value and report it to the backend as a rate-per-second. A variety of networking
-metrics may be reported monotonically, and this metric type provides a convenient means of recording
-these values, at the expense of a slower time-to-first metric.
-
 Call `set()` when an event occurs:
 
 ```python

--- a/docs/spectator/lang/py/meters/monotonic-counter.md
+++ b/docs/spectator/lang/py/meters/monotonic-counter.md
@@ -2,12 +2,6 @@
 
 See [Monotonic Counter](../../../patterns/monotonic-counter.md) for the concept.
 
-A Monotonic Counter (float) is used to measure the rate at which an event is occurring, when the
-source data is a monotonically increasing number. A minimum of two samples must be sent, in order to
-calculate a delta value and report it to the backend as a rate-per-second. A variety of networking
-metrics may be reported monotonically, and this metric type provides a convenient means of recording
-these values, at the expense of a slower time-to-first metric.
-
 Call `set()` when an event occurs:
 
 ```python

--- a/docs/spectator/lang/py/meters/percentile-dist-summary.md
+++ b/docs/spectator/lang/py/meters/percentile-dist-summary.md
@@ -2,16 +2,6 @@
 
 See [Percentile Distribution Summary](../../../patterns/percentile-dist-summary.md) for the concept.
 
-The value tracks the distribution of events, with percentile estimates. It is similar to a
-`PercentileTimer`, but more general, because the size does not have to be a period of time.
-
-For example, it can be used to measure the payload sizes of requests hitting a server or the
-number of records returned from a query.
-
-In order to maintain the data distribution, they have a higher storage cost, with a worst-case of
-up to 300X that of a standard Distribution Summary. Be diligent about any additional dimensions
-added to Percentile Distribution Summaries and ensure that they have a small bounded cardinality.
-
 Call `record()` with a value:
 
 ```python

--- a/docs/spectator/lang/py/meters/percentile-timer.md
+++ b/docs/spectator/lang/py/meters/percentile-timer.md
@@ -1,14 +1,6 @@
 # Percentile Timer
 
-The value is the number of seconds that have elapsed for an event, with percentile estimates.
-
-This metric type will track the data distribution by maintaining a set of Counters. The
-distribution can then be used on the server side to estimate percentiles, while still
-allowing for arbitrary slicing and dicing based on dimensions.
-
-In order to maintain the data distribution, they have a higher storage cost, with a worst-case of
-up to 300X that of a standard Timer. Be diligent about any additional dimensions added to Percentile
-Timers and ensure that they have a small bounded cardinality.
+See [Percentile Timer](../../../patterns/percentile-timer.md) for the concept.
 
 Call `record()` with a value:
 

--- a/docs/spectator/lang/py/meters/timer.md
+++ b/docs/spectator/lang/py/meters/timer.md
@@ -1,6 +1,6 @@
 # Timer
 
-A Timer is used to measure how long (in seconds) some event is taking.
+See [Timer](../../../core/meters/timer.md) for the concept.
 
 Call `record()` with a value:
 


### PR DESCRIPTION
The concept of each meter type now lives in exactly one place: the corresponding core/meters/ or patterns/ page. Per-language meter pages become a thin shell: heading, "See [<Meter>] for the concept." backlink, code example(s), and any genuine language-specific notes.

- Add the missing backlink to the 20 core-meter language pages (counter, gauge, timer, dist-summary across cpp, go, nodejs, py, java).
- Strip the duplicated concept paragraphs from those 16 non-Java pages. Java's core-meter pages were already code-focused and only needed the backlink.
- Strip the duplicated concept / lifecycle / cardinality-cost prose from the per-language age-gauge, max-gauge, monotonic-counter, monotonic- counter-uint, percentile-dist-summary, percentile-timer pages (4 non-Java languages each). The Age Gauge admin-server cleanup curl examples are already in the concept page.
- Drop the misleading "C++ is the only thin client that accepts floats" note from cpp/dist-summary.md. Verified against source: nodejs also accepts floats (JS number is float); go and python require integers. The honest comparison would go stale every API shift -- readers can see the language's Record signature directly.
- Drop the inaccurate float note that the script also added to cpp/ percentile-dist-summary.md: the cpp PercentileDistributionSummary. Record takes int64_t, not double.

Net -308 lines across 44 files.