### PR TITLE
clarify Netflix-internal wording in a few spots

### DIFF
--- a/docs/spectator/lang/java/ext/jvm-gc.md
+++ b/docs/spectator/lang/java/ext/jvm-gc.md
@@ -12,8 +12,9 @@ some basic GC logging and metrics.
 
 ## Getting Started
 
-For using it internally at Netflix, see the [Java Usage](../usage.md) guide, otherwise
-keep reading this section.
+If you are running at Netflix, the standard platform initialization already wires this up via the
+[Netflix Integration](../usage.md#netflix-integration) — no further action required. Otherwise,
+follow the instructions below.
 
 ### Requirements
 

--- a/docs/spectator/lang/java/servo-migration.md
+++ b/docs/spectator/lang/java/servo-migration.md
@@ -6,8 +6,8 @@ It was done as a separate project to avoid breaking backwards compatibility for 
 
 From a user perspective, both will be supported for a long time, but most of our efforts for
 future improvement will go to Spectator. For new code, it is recommended to use the spectator
-API. If running [at Netflix](usage.md), the correct bindings will be in place for both Servo
-and Spectator.
+API. If running [at Netflix](usage.md#netflix-integration), the correct bindings will be in place for
+both Servo and Spectator.
 
 ## Differences
 

--- a/docs/spectator/lang/py/migrations.md
+++ b/docs/spectator/lang/py/migrations.md
@@ -180,8 +180,8 @@ registry.gauge("server.queueSize", ttl_seconds=120).set(10)
 [SpectatorD] sidecar which is bundled with all standard AMIs and containers. If you must
 have the previous direct publishing behavior, because SpectatorD is not yet available on the
 platform where your code runs, then you can pin to version `0.1.18`.
-* The internal Netflix configuration companion library is no longer required and this dependency
-may be dropped from your project.
+* **Netflix-only:** the internal configuration companion library is no longer required and this
+dependency may be dropped from your project.
 * The API surface area remains unchanged to avoid breaking library consumers, and standard uses of
 `GlobalRegistry` helper methods for publishing metrics continue to work as expected. Several helper
 methods on meter classes are now no-ops, always returning values such as `0` or `nan`. If you want


### PR DESCRIPTION
Three places had Netflix-internal references that read awkwardly for external readers without making the Netflix-vs-external distinction obvious. Targeted fixes:

- ext/jvm-gc.md: "For using it internally at Netflix, see the [Java Usage] guide, otherwise keep reading this section." rewritten as a clear conditional: if you're at Netflix the platform wires this up automatically (linking the Netflix Integration anchor directly); otherwise follow the steps below.
- py/migrations.md: prefix the "internal Netflix configuration companion library" bullet with **Netflix-only:** so external readers know to skip it. Kept for completeness of the 0.2 migration notes.
- java/servo-migration.md: tighten the "[at Netflix](usage.md)" link to point at the #netflix-integration anchor rather than the top of the page.

Deliberately left unchanged: the "Note, if you are building an app at Netflix, then this should happen automatically via the normal platform initialization" callouts on the six JVM ext pages. These read as a normal "platform shortcut" hint that's clear in either direction. Also left the broader "at Netflix" mentions in alerting-philosophy, overview, percentile-timer, etc. -- those are factual examples, not external-vs-internal ambiguity.