### PR TITLE
usage consistency + java registry overview

### DIFF
--- a/docs/spectator/lang/cpp/migrations.md
+++ b/docs/spectator/lang/cpp/migrations.md
@@ -9,7 +9,7 @@ which it sends metrics to SpectatorD.
 
 `spectator.Registry` now supports 3 different writers. The WriterType is specified through a WriterConfig object.
 
-See [Usage > Output Locations](usage.md#output-locations) for more details.
+See [Usage > Output Location](usage.md#output-location) for more details.
 
 #### Common Tags
 

--- a/docs/spectator/lang/cpp/usage.md
+++ b/docs/spectator/lang/cpp/usage.md
@@ -1,21 +1,21 @@
 # spectator-cpp Usage
 
-CPP thin-client [metrics library] for use with [Atlas] and [SpectatorD].
+C++ thin-client [metrics library] for use with [Atlas] and [SpectatorD].
 
 [metrics library]: https://github.com/Netflix/spectator-cpp
 [Atlas]: ../../../overview.md
 [SpectatorD]: ../../agent/usage.md
 
-## Supported CPP Versions
+## Supported C++ Versions
 
 This library currently utilizes C++ 20.
 
 ## Installing & Building
 
 If your project uses CMake, you can easily integrate this library by calling `add_subdirectory()`
-on the root folder. To build the Spectator-CPP thin client independently, follow the Docker
+on the root folder. To build the spectator-cpp thin client independently, follow the Docker
 container instructions at [Dockerfiles](https://github.com/Netflix/spectator-cpp/tree/main/Dockerfiles).
-The container provides a minimal build environment with g++-13, python3, and conan. Spectator-CPP
+The container provides a minimal build environment with g++-13, python3, and conan. spectator-cpp
 relies on just three external dependencies (spdlog, gtest, and boost), which are managed automatically
 via conan.
 
@@ -123,7 +123,7 @@ for general guidelines on metrics naming and restrictions.
 * [Percentile Timer](./meters/percentile-timer.md)
 * [Timer](./meters/timer.md)
 
-## Output Locations
+## Output Location
 
 `spectator.Registry` supports three output writer types: Memory Writer, UDP Writer, and Unix Domain
 Socket (UDS) Writer. To specify the writer type, initialize the Registry with a `Config` object. A

--- a/docs/spectator/lang/java/registry/overview.md
+++ b/docs/spectator/lang/java/registry/overview.md
@@ -32,6 +32,50 @@ The core Spectator library, `spectator-api`, comes with the following [Registry]
         application for function properly.
 </table>
 
+`DefaultRegistry` and `NoopRegistry` are useful for tests or local development, but they
+do not publish data anywhere. For applications that need to report to Atlas, two additional
+registry implementations are available as separate Gradle modules.
+
+## Reporting Registries
+
+### SidecarRegistry
+
+[`spectator-reg-sidecar`](https://github.com/Netflix/spectator/tree/main/spectator-reg-sidecar)
+publishes data through a local [SpectatorD](../../../agent/usage.md) agent over UDP — the
+same pattern used by the other Spectator client libraries (C++, Go, Node.js, Python). The
+Java client does not support the Unix Domain Socket transport that SpectatorD also
+provides.
+
+```groovy
+dependencies {
+    compile "com.netflix.spectator:spectator-reg-sidecar:latest.release"
+}
+```
+
+```java
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.sidecar.SidecarConfig;
+import com.netflix.spectator.sidecar.SidecarRegistry;
+
+// Accept defaults: spectatord on udp://127.0.0.1:1234
+SidecarConfig config = key -> null;
+Registry registry = new SidecarRegistry(Clock.SYSTEM, config);
+```
+
+The output location can be overridden via the `sidecar.output-location` config key.
+Supported values match those of [SpectatorD](../../../agent/usage.md): `udp://host:port`,
+`file://path`, `stdout`, `stderr`, `none`.
+
+### AtlasRegistry
+
+[`spectator-reg-atlas`](https://github.com/Netflix/spectator/tree/main/spectator-reg-atlas)
+publishes directly to an Atlas aggregator service, without routing through SpectatorD. At
+Netflix this is what SBN applications get by default via
+[Netflix Integration](../usage.md#netflix-integration); users do not need to construct it
+themselves.
+
+## Using a Registry
+
 It is recommended for libraries to write code against the [Registry] interface and allow the
 implementation to get injected by the user of the library. The simplest way is to accept the
 Registry via the constructor, for example:

--- a/docs/spectator/lang/java/usage.md
+++ b/docs/spectator/lang/java/usage.md
@@ -1,3 +1,5 @@
+# Java Usage
+
 ## Project
 
 * [Source](https://github.com/Netflix/spectator)


### PR DESCRIPTION
cpp/usage.md:
- "Supported CPP Versions" -> "Supported C++ Versions" and use C++ in the page prose. "spectator-cpp" stays as the package name. Lowercase "Spectator-CPP" -> "spectator-cpp" in build instructions.
- Rename "Output Locations" to "Output Location" to match go/nodejs/ py. Update the cpp/migrations.md anchor.

java/usage.md:
- Add a "# Java Usage" page heading. Other languages had a top-level heading on usage.md; java was the only one starting with "## Project" and so had no rendered page title beyond the nav fallback. Did not use "thin-client" framing here because at Netflix "thin-client" specifically means clients routing through spectatord -- java has both that path (SidecarRegistry) and a direct path (AtlasRegistry, the default via SBN).

java/registry/overview.md:
- Add a "Reporting Registries" section covering SidecarRegistry and AtlasRegistry. The existing table only listed DefaultRegistry and NoopRegistry, which are useful for testing/local but never publish data. Show the spectator-reg-sidecar Gradle dep and the minimal SidecarRegistry setup so java users can wire it up parallel to the other languages' Registry construction. Note that the java client does not support UDS (only UDP). Point readers at the Netflix Integration section for AtlasRegistry -- SBN applications get it by default and don't construct it themselves.