### PR TITLE
java audit: monotonic counters, patterns cleanup

### DIFF
--- a/docs/spectator/lang/java/meters/gauge.md
+++ b/docs/spectator/lang/java/meters/gauge.md
@@ -121,31 +121,13 @@ PolledMeter.using(registry)
 
 ### Monotonic Counters
 
-A common technique used by some libraries is to expose a monotonically increasing counter that
-represents the number of events since the system was initialized. An example of that in the JDK
-is [ThreadPoolExecutor.getCompletedTaskCount], which returns the number of completed tasks on
-the thread pool.
+For sources that expose a monotonically increasing cumulative value (e.g.
+`ThreadPoolExecutor.getCompletedTaskCount`), use `PolledMeter.monitorMonotonicCounter` to
+sample the absolute value and report the delta as a rate. See the
+[Monotonic Counter](monotonic-counter.md) page for details and examples.
 
-[ThreadPoolExecutor.getCompletedTaskCount]: https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/concurrent/ThreadPoolExecutor.html#getCompletedTaskCount()
-
-For sources like this, the `monitorMonotonicCounter` method can be used:
-
-```java
-// For an implementation of Number
-LongAdder tasks = new LongAdder();
-PolledMeter.using(registry)
-  .withName("pool.completedTasks")
-  .monitorMonotonicCounter(tasks);
-
-// Or using a lambda
-ThreadPoolExecutor executor = ...
-PolledMeter.using(registry)
-  .withName("pool.completedTasks")
-  .monitorMonotonicCounter(executor, ThreadPoolExecutor::getCompletedTaskCount);
-```
-
-For thread pools specifically, there are better options for getting standard metrics. See the docs
-for the [Thread Pools extension](../ext/thread-pools.md) for more information.
+For thread pools specifically, there are better options for getting standard metrics — see
+the [Thread Pools extension](../ext/thread-pools.md).
 
 ## Active Gauges
 

--- a/docs/spectator/lang/java/meters/monotonic-counter.md
+++ b/docs/spectator/lang/java/meters/monotonic-counter.md
@@ -5,22 +5,29 @@ See [Monotonic Counter](../../../patterns/monotonic-counter.md) for the concept.
 Java does not expose a dedicated monotonic counter meter; the equivalent is the
 [Polled Meter](../patterns/polled-meter.md) helper's `monitorMonotonicCounter`, which
 periodically samples a function returning the current absolute value and reports the
-per-second rate of the delta:
+per-second rate of the delta. A minimum of two polls is required before the first metric
+is reported.
+
+Two common forms:
 
 ```java
-public class Worker {
+// Lambda over a source that exposes a long-valued cumulative count.
+PolledMeter.using(registry)
+    .withName("pool.completedTasks")
+    .monitorMonotonicCounter(executor, ThreadPoolExecutor::getCompletedTaskCount);
 
-  @Inject
-  public Worker(Registry registry, ThreadPoolExecutor executor) {
-    PolledMeter.using(registry)
-        .withName("threadpool.completedTasks")
-        .monitorMonotonicCounter(executor, ThreadPoolExecutor::getCompletedTaskCount);
-  }
-}
+// A Number instance that the caller updates directly.
+LongAdder tasks = new LongAdder();
+PolledMeter.using(registry)
+    .withName("pool.completedTasks")
+    .monitorMonotonicCounter(tasks);
 ```
 
-For double-valued sources, use `monitorMonotonicCounterDouble`. A minimum of two polls is
-required before the first metric is reported.
+For double-valued sources, use `monitorMonotonicCounterDouble`.
+
+If the polled value decreases between samples (counter reset, source restart, or numeric
+wraparound), that interval's delta is dropped and the new value becomes the baseline for
+the next delta. See [Counter resets and wraparounds](../../../patterns/monotonic-counter.md#counter-resets-and-wraparounds).
 
 Java is long-based, so there is no separate uint64 variant — `monitorMonotonicCounter` covers
 both signed and OS-counter use cases.

--- a/docs/spectator/lang/java/patterns/gauge-poller.md
+++ b/docs/spectator/lang/java/patterns/gauge-poller.md
@@ -1,6 +1,0 @@
-# Gauge Poller
-
-Helper for polling gauges in a background thread. A shared executor is used with a single
-thread. If registered gauge methods are cheap as they should be, then this should be plenty
-of capacity to process everything regularly. If not, then this will help limit the damage to
-a single core and avoid causing problems for the application.

--- a/docs/spectator/lang/java/patterns/interval-counter.md
+++ b/docs/spectator/lang/java/patterns/interval-counter.md
@@ -1,3 +1,38 @@
 # Interval Counter
 
-A counter that also keeps track of the time since last update.
+`IntervalCounter` is a [Counter](../meters/counter.md) that also reports the time in seconds
+since the last update. Useful when you want an alert that fires if a counter stops being
+incremented — the "Time Since Last Success" pattern applied to event-rate signals rather than
+a separately-tracked timestamp.
+
+Two time series are published with the same name, distinguished by the `statistic` tag:
+
+* `statistic=count` — the underlying counter, reported as a rate-per-second.
+* `statistic=duration` — a gauge of the seconds elapsed since the last `increment()` call.
+
+Example:
+
+```java
+public class Job {
+
+  private final IntervalCounter completions;
+
+  @Inject
+  public Job(Registry registry) {
+    completions = IntervalCounter.get(registry, registry.createId("job.completions"));
+  }
+
+  public void run() {
+    doWork();
+    completions.increment();
+  }
+}
+```
+
+Then alert on the duration series rising above a threshold, e.g.
+`statistic,duration,:eq,name,job.completions,:eq,:and,:max,3600,:gt`.
+
+Implementation note: `IntervalCounter` uses [Polled Meter](polled-meter.md) with
+[`Functions.age`](https://www.javadoc.io/static/com.netflix.spectator/spectator-api/latest/com/netflix/spectator/api/Functions.html#age-com.netflix.spectator.api.Clock-)
+under the hood. If you only need the freshness signal (without a separate counter), use a
+plain polled meter directly — see [Age Gauge](../meters/age-gauge.md).

--- a/docs/spectator/patterns/monotonic-counter.md
+++ b/docs/spectator/patterns/monotonic-counter.md
@@ -17,10 +17,27 @@ slower time-to-first-data point than a standard counter.
 * **Signed / double** — the default. Suitable when the source fits in a signed 64-bit
   integer or double and is not expected to overflow.
 * **uint64** — required when reading from a source that uses unsigned 64-bit semantics
-  (most OS-level interface counters) so that a wrap-around past `2^63` is not interpreted
-  as a backward jump.
+  (most OS-level interface counters), so that a wrap past `2^64 - 1` back to `0` is
+  reported correctly as a positive delta rather than appearing as a backward jump.
 
 Java is long-based and does not need a separate uint variant.
+
+## Counter resets and wraparounds
+
+When the polled value goes **down** between samples, the library cannot tell whether the
+source was reset (e.g. process restart, JMX counter cleared) or wrapped past its numeric
+limit. Behavior depends on the variant:
+
+* **Signed / double** — drops the sample for that interval and uses the new value as the
+  baseline for the next delta. The decrease itself is not reported; one interval's worth
+  of activity is lost, then reporting resumes normally.
+* **uint64** — computes the wrap delta `(2^64 - previous) + current` and reports that.
+  spectatord additionally caps this: if the computed delta exceeds `2^63`, it is treated
+  as an unexpected rollover (e.g. a real reset masquerading as a wrap) and `0` is
+  reported instead.
+
+If your source can legitimately reset, prefer a regular [Counter](../core/meters/counter.md)
+with explicit `increment()` calls so each event is recorded individually.
 
 ## Languages
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -275,7 +275,6 @@ nav:
         - Timer: spectator/lang/java/meters/timer.md
       - Patterns:
         - Cardinality Limiter: spectator/lang/java/patterns/cardinality-limiter.md
-        - Gauge Poller: spectator/lang/java/patterns/gauge-poller.md
         - Interval Counter: spectator/lang/java/patterns/interval-counter.md
         - Long Task Timer: spectator/lang/java/patterns/long-task-timer.md
         - Polled Meter: spectator/lang/java/patterns/polled-meter.md


### PR DESCRIPTION
- Delete patterns/gauge-poller.md and remove from nav. GaugePoller is package-private in spectator-api -- documenting it as a "pattern" was misleading. The user-facing API is PolledMeter (already documented).
- Expand patterns/interval-counter.md from a 3-line stub to a real page: describe the count + duration time series it publishes, show the canonical IntervalCounter.get(registry, id) setup pattern, and point at Functions.age / age-gauge for the underlying implementation.
- meters/monotonic-counter.md: add the LongAdder/Number variant example alongside the lambda example. Both forms exist on PolledMeter.monitorMonotonicCounter and the old gauge.md subsection showed both.
- meters/gauge.md: trim the "Monotonic Counters" subsection now that meters/monotonic-counter.md has full coverage. Leave a one-paragraph pointer plus the existing thread-pools cross-reference.
- patterns/monotonic-counter.md: clarify overflow / reset behavior, verified against spectatord and spectator-java sources. Signed / double counters drop decreases (real reset and wraparound look the same), losing one interval and resuming. uint64 counters compute the wrap delta (2^64 - previous) + current; spectatord caps the result at 2^63 and reports 0 if the computed delta exceeds that threshold. Also corrected an earlier note that said "wrap past 2^63" -- the actual unsigned wrap point is 2^64 - 1; 2^63 is the safety threshold.