### PR TITLE
align java meter example names with other languages

### DIFF
--- a/docs/spectator/lang/java/meters/age-gauge.md
+++ b/docs/spectator/lang/java/meters/age-gauge.md
@@ -15,7 +15,7 @@ public class Job {
   @Inject
   public Job(Registry registry) {
     lastSuccess = PolledMeter.using(registry)
-        .withName("job.timeSinceLastSuccess")
+        .withName("time.sinceLastSuccess")
         .monitorValue(new AtomicLong(System.currentTimeMillis()), Functions.AGE);
   }
 
@@ -36,6 +36,6 @@ ManualClock clock = new ManualClock();
 Registry registry = new DefaultRegistry(clock);
 
 PolledMeter.using(registry)
-    .withName("job.timeSinceLastSuccess")
+    .withName("time.sinceLastSuccess")
     .monitorValue(new AtomicLong(clock.wallTime()), Functions.age(clock));
 ```

--- a/docs/spectator/lang/java/meters/max-gauge.md
+++ b/docs/spectator/lang/java/meters/max-gauge.md
@@ -7,16 +7,16 @@ Create one via the [Registry](../registry/overview.md):
 ```java
 public class Queue {
 
-  private final Gauge queueDepth;
+  private final Gauge queueSize;
 
   @Inject
   public Queue(Registry registry) {
-    queueDepth = registry.maxGauge("queue.depth");
+    queueSize = registry.maxGauge("server.queueSize");
   }
 
   public void enqueue(Object obj) {
     impl.enqueue(obj);
-    queueDepth.set(impl.size());
+    queueSize.set(impl.size());
   }
 }
 ```

--- a/docs/spectator/lang/java/meters/percentile-dist-summary.md
+++ b/docs/spectator/lang/java/meters/percentile-dist-summary.md
@@ -14,7 +14,7 @@ public class Server {
   @Inject
   public Server(Registry registry) {
     requestSize = PercentileDistributionSummary.builder(registry)
-        .withId(registry.createId("server.request.size"))
+        .withId(registry.createId("server.requestSize"))
         .build();
   }
 

--- a/docs/spectator/lang/java/meters/percentile-timer.md
+++ b/docs/spectator/lang/java/meters/percentile-timer.md
@@ -16,7 +16,7 @@ public class Server {
   public Server(Registry registry) {
     this.registry = registry;
     requestLatency = PercentileTimer.builder(registry)
-        .withId(registry.createId("server.request.latency", "status", "200"))
+        .withId(registry.createId("server.requestLatency", "status", "200"))
         .build();
 ```
 


### PR DESCRIPTION
Cross-language consistency pass: pick one canonical example metric name per meter type and use it in all five language pages. Java was the outlier in four cases; the spectatord-backed clients (cpp, go, nodejs, py) already agreed.

- max-gauge: queue.depth -> server.queueSize (and the local variable queueDepth -> queueSize to match).
- percentile-timer: server.request.latency -> server.requestLatency. Also fixes the camelCase naming-conventions violation; "use camelCase" is the rule in concepts/naming.md.
- percentile-dist-summary: server.request.size -> server.requestSize. Same camelCase fix.
- age-gauge: job.timeSinceLastSuccess -> time.sinceLastSuccess.

Did not align meters where Java is showing a legitimately different idiom (counter's class-field pattern, gauge's PolledMeter scenarios, monotonic-counter's JMX ThreadPoolExecutor example).