### PR TITLE
performance.md: add thread safety section

### DIFF
--- a/docs/spectator/core/performance.md
+++ b/docs/spectator/core/performance.md
@@ -60,6 +60,26 @@ maintain a set of bucket counters. Storage cost is up to ~300x that of the basic
 Distribution Summary. Use them only for one or two key indicators per application, set an
 appropriate range, and keep tag cardinality bounded.
 
+## Thread Safety
+
+Meter instances returned by a `Registry` are safe to use concurrently from multiple threads
+in every Spectator client library. Holding a counter (or timer, etc.) in a shared field and
+calling `increment()` / `record()` from many threads is the intended pattern.
+
+A few exceptions to keep in mind:
+
+* **Java `BatchUpdater`** — the updater returned by `Counter.batchUpdater(...)` (and the
+  timer/dist-summary equivalents) is **single-thread only**. Give each thread its own
+  updater, or fall back to direct meter calls for multi-threaded code paths. See
+  [Batch Updates](../lang/java/meters/counter.md#batch-updates).
+* **Polled gauges** — the value source you hand to a polled gauge (for example, the
+  `AtomicLong` passed to `PolledMeter.monitorValue` in Java) must itself be thread-safe.
+  Spectator polls the source from a background thread; if your code mutates it from
+  another thread, use an atomic or synchronize externally.
+* **Python multiprocessing** — see the
+  [caveats](../lang/py/usage.md#caveats-multiprocessing) for fork-based workers that
+  don't share thread-level state.
+
 ## Keep tag cardinality bounded
 
 Every distinct combination of tag values produces a new time series. Avoid putting


### PR DESCRIPTION
User-support topic that wasn't documented anywhere. Meter instances from a Registry are safe to use concurrently in every client library; the noteworthy exceptions are:

- Java BatchUpdater is single-thread only.
- Polled gauges only see the source's current value -- the source itself must be thread-safe (use an atomic or synchronize externally if mutated from multiple threads).
- Python multiprocessing has fork-based caveats already documented on the py usage page; cross-link to it.

Kept the section short and use-case focused. Did not enumerate the specific implementation (AtomicDouble, threading.Lock, std::mutex, etc.) -- those are not what an instrumentation user needs to know.