### PR TITLE
editing pass: typos, grammar, awkward phrasing

### DIFF
--- a/docs/api/graph/color-palettes.md
+++ b/docs/api/graph/color-palettes.md
@@ -135,7 +135,7 @@ Shades of red.
 
 ## Custom
 
-A custom color palette can be provided for a graph by using a list of  comma separated
+A custom color palette can be provided for a graph by using a list of comma-separated
 [hex color](../../asl/ref/color.md) values following the ASL list format `(,HEX,HEX,HEX,)`.
 This is mainly used to customize the colors for the result of a group by where you
 cannot set the color for each line using the list.

--- a/docs/asl/alerting-expressions.md
+++ b/docs/asl/alerting-expressions.md
@@ -18,7 +18,7 @@ high CPU usage for a period:
 /api/v1/graph?s=e-3h&e=2012-01-01T07:00&tz=UTC&l=0&h=100&q=nf.app,alerttest,:eq,name,ssCpuUser,:eq,:and,:sum
 @@@
 
-Lets say we want to trigger an alert when the CPU usage goes above 80%. To do that simply use the
+Let's say we want to trigger an alert when the CPU usage goes above 80%. To do that simply use the
 [:gt](ref/gt.md) operator and append `80,:gt` to the query:
 
 @@@ atlas-graph { show-expr=false }
@@ -33,7 +33,7 @@ when everything is fine.
 Our threshold alert above will trigger if the CPU usage is ever recorded to be above the threshold.
 Alert conditions are often combined with a check for the number of occurrences. This is done by
 using the [:rolling-count](ref/rolling-count.md) operator to get a line showing how many times
-the input signal has been true withing a specified window and then applying a second threshold to
+the input signal has been true within a specified window and then applying a second threshold to
 the rolling count.
 
 @@@ atlas-example

--- a/docs/asl/alerting-philosophy.md
+++ b/docs/asl/alerting-philosophy.md
@@ -1,4 +1,4 @@
-It is recommended for all alerts to adhere to the follow guidelines:
+It is recommended for all alerts to adhere to the following guidelines:
 
 1. [Keep conditions simple](#keep-it-simple).
 2. [Alerts should be actionable](#actionable-alerts).
@@ -54,7 +54,7 @@ instance, it shouldn't send out a notification unless there is a failure to perf
 the action. If you want a summary of cluster health, then use dashboards or
 reporting tools for this function; don't attempt to do this via alert notifications.
 
-Alerts should check something important. To setup effective alerts, you need to
+Alerts should check something important. To set up effective alerts, you need to
 understand the application and have ways to detect failures for critical functionality.
 Avoid general system-type alerts that won't be investigated. For example, should
 you alert on high CPU usage? If you have done squeeze testing and you have
@@ -157,7 +157,7 @@ startup time.
 
 For the CPU example, first reconsider whether general system check alerts are
 actually useful. Is it going to help you catch a real problem and be investigated
-when it triggers? If not, don't setup an alert on CPU and rely on alerts that
+when it triggers? If not, don't set up an alert on CPU and rely on alerts that
 check for failures on the critical path.
 
 If it is useful and you have squeeze testing results or other information so

--- a/docs/concepts/time-series.md
+++ b/docs/concepts/time-series.md
@@ -43,7 +43,7 @@ the [naming](naming.md) docs for more information.
 ## Metric
 
 A metric is a specific quantity being measured, e.g., the number of requests received by a server.
-In casual language about Atlas metric is often used interchangeably with
+In casual language about Atlas, *metric* is often used interchangeably with
 [time series](#time-series). A time series is one way to track a metric and is the method
 supported by Atlas. In most cases there will be many time series for a given metric. Going back
 to the example, request count would usually be tagged with additional dimensions such as status

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -245,7 +245,7 @@ splitting the traffic up, so it goes to the correct shard. The set of mirror ins
 are assigned based on slots from the [Edda](https://github.com/Netflix/edda)
 [autoScalingGroups API](https://netflix.github.io/edda/rest-api/#apiv2group). Since
 the set of instances for the mirrors change rarely, the publish instances can cache the Edda
-response and still retain successfully publish most data if Edda fails. If an instance is replaced
+response and still successfully publish most data if Edda fails. If an instance is replaced
 and we can't update data we would have partial loss for a single shard if the same shard was
 missing in another mirror.
 

--- a/docs/spectator/lang/cpp/usage.md
+++ b/docs/spectator/lang/cpp/usage.md
@@ -65,7 +65,7 @@ created.
 
 Each metric stored in Atlas is uniquely identified by the combination of the name and the tags
 associated with it. In `spectator-cpp`, this data is represented with `MeterId` objects, created
-by the `Registry`. The `CreateNewId()` method returns new a `MeterId` object, which has extra
+by the `Registry`. The `CreateNewId()` method returns a `MeterId` object, which has extra
 common tags applied, and which can be further customized by calling the `WithTag()` and
 `WithTags()` methods. Each `MeterId` will create and store a validated subset of the `spectatord`
 protocol line to be written for each `Meter`, when it is instantiated. Manipulating the tags with

--- a/docs/spectator/lang/go/migrations.md
+++ b/docs/spectator/lang/go/migrations.md
@@ -77,7 +77,7 @@ Note that common tags sourced by [spectatord](https://github.com/Netflix-Skunkwo
 2. Update imports for `Config` and `Registry`, and use the `meters` package instead of `spectator` for Meters.
 3. If you want to collect runtime metrics, add the [spectator-go-runtime-metrics](https://github.com/Netflix/spectator-go-runtime-metrics)
    library, and follow the instructions in the README.
-4. If you use `PercentileDistributionSummary` or `PercentileTimer`, then  you need to update your code to use the
+4. If you use `PercentileDistributionSummary` or `PercentileTimer`, then you need to update your code to use the
    respective functions provided by the `Registry` to initialize these meters.
 5. Remove the dependency on the `spectator-go` internal configuration library - it is no longer required.
 6. There is no longer an option to `start()` or `stop()` the `Registry` at runtime. If you need to configure a `Registry`

--- a/docs/spectator/lang/java/ext/jvm-buffer-pools.md
+++ b/docs/spectator/lang/java/ext/jvm-buffer-pools.md
@@ -6,7 +6,7 @@ provided by the JDK.
 
 ## Getting Started
 
-To get information about buffer pools in Spectator, just setup registration of standard MXBeans.
+To get information about buffer pools in Spectator, just set up registration of standard MXBeans.
 Note, if you are building an app at Netflix, then this should happen automatically via the normal
 platform initialization.
 

--- a/docs/spectator/lang/java/ext/jvm-classloading.md
+++ b/docs/spectator/lang/java/ext/jvm-classloading.md
@@ -5,7 +5,7 @@ provided by the JDK to monitor the number of classes loaded and unloaded.
 
 ## Getting Started
 
-To get information about classloading in Spectator, just setup registration of standard MXBeans.
+To get information about classloading in Spectator, just set up registration of standard MXBeans.
 Note, if you are building an app at Netflix, then this should happen automatically via the normal
 platform initialization.
 

--- a/docs/spectator/lang/java/ext/jvm-compilation.md
+++ b/docs/spectator/lang/java/ext/jvm-compilation.md
@@ -5,7 +5,7 @@ provided by the JDK to monitor the time spent compiling code, for each compiler 
 
 ## Getting Started
 
-To get information about compilation in Spectator, just setup registration of standard MXBeans.
+To get information about compilation in Spectator, just set up registration of standard MXBeans.
 Note, if you are building an app at Netflix, then this should happen automatically via the normal
 platform initialization.
 

--- a/docs/spectator/lang/java/ext/jvm-memory-pools.md
+++ b/docs/spectator/lang/java/ext/jvm-memory-pools.md
@@ -5,7 +5,7 @@ provided by the JDK to monitor the sizes of java memory spaces such as perm gen,
 
 ## Getting Started
 
-To get information about memory pools in Spectator, just setup registration of standard MXBeans.
+To get information about memory pools in Spectator, just set up registration of standard MXBeans.
 Note, if you are building an app at Netflix, then this should happen automatically via the normal
 platform initialization.
 

--- a/docs/spectator/lang/java/ext/jvm-safepoint.md
+++ b/docs/spectator/lang/java/ext/jvm-safepoint.md
@@ -6,7 +6,7 @@ Uses Hotspot mbean to access the spent in and getting to [safepoints].
 
 ## Getting Started
 
-To get information about compilation in Spectator, just setup registration of standard MXBeans.
+To get information about compilation in Spectator, just set up registration of standard MXBeans.
 Note, if you are building an app at Netflix, then this should happen automatically via the normal
 platform initialization.
 

--- a/docs/spectator/lang/java/ext/jvm-threads.md
+++ b/docs/spectator/lang/java/ext/jvm-threads.md
@@ -5,7 +5,7 @@ provided by the JDK to monitor the number of active threads and threads started.
 
 ## Getting Started
 
-To get information about threads in Spectator, just setup registration of standard MXBeans. Note,
+To get information about threads in Spectator, just set up registration of standard MXBeans. Note,
 if you are building an app at Netflix, then this should happen automatically via the normal platform
 initialization.
 

--- a/docs/spectator/lang/java/meters/counter.md
+++ b/docs/spectator/lang/java/meters/counter.md
@@ -2,7 +2,7 @@
 
 See [Counter](../../../core/meters/counter.md) for the concept.
 
-Counters are created using the [Registry](../registry/overview.md), which is be setup as part of
+Counters are created using the [Registry](../registry/overview.md), which will be set up as part of
 application initialization. For example:
 
 ```java

--- a/docs/spectator/lang/java/meters/dist-summary.md
+++ b/docs/spectator/lang/java/meters/dist-summary.md
@@ -3,7 +3,7 @@
 See [Distribution Summary](../../../core/meters/dist-summary.md) for the concept.
 
 Distribution Summaries are created using the [Registry](../registry/overview.md), which will be
-setup as part of application initialization. For example:
+set up as part of application initialization. For example:
 
 ```java
 public class Server {

--- a/docs/spectator/lang/java/usage.md
+++ b/docs/spectator/lang/java/usage.md
@@ -80,7 +80,7 @@ public class Server {
         // Update the counter id with dimensions based on the request. The
         // counter will then be looked up in the registry which should be
         // fairly cheap, such as lookup of id object in a ConcurrentHashMap.
-        // However, it is more expensive than having a local variable seti
+        // However, it is more expensive than having a local variable set
         // to the counter.
         final Id cntId = requestCountId
           .withTag("country", req.country())

--- a/docs/spectator/lang/nodejs/usage.md
+++ b/docs/spectator/lang/nodejs/usage.md
@@ -450,7 +450,7 @@ describe("Metrics Test", (): void => {
 
 ### Protocol Parser
 
-A [SpectatorD] line protocol parser is available, which ca be used for validating the results
+A [SpectatorD] line protocol parser is available, which can be used for validating the results
 captured by a `MemoryWriter`.
 
 ```typescript

--- a/docs/spectator/specs/ipc.md
+++ b/docs/spectator/specs/ipc.md
@@ -14,7 +14,7 @@ implementations.
 
 * `ipc.protocol`: A short name of the network protocol in use, eg. `grpc`, `http_1`,
   `http_2`, `udp`, etc ...
-* `ipc.vip`: The Eureka VIP address used to find the the server.
+* `ipc.vip`: The Eureka VIP address used to find the server.
 * `ipc.result`: Was this considered by the implementation to be successful. Allowed Values =
   [`success`, `failure`].
 * `ipc.status`: One of a predefined list of status values indicating the general result, eg.


### PR DESCRIPTION
Polish pass across the site -- no structural or factual changes, just clearer prose.

Typos:
- alerting-expressions.md: "Lets say" -> "Let's say", "withing" -> "within"
- alerting-philosophy.md: "the follow guidelines" -> "the following guidelines", and two "setup" verb -> "set up" cases.
- specs/ipc.md: "the the server" -> "the server"
- nodejs/usage.md: "ca be used" -> "can be used"
- cpp/usage.md: "returns new a" -> "returns a"
- java/usage.md: "set to the counter" had a typo "seti"
- java/meters/counter.md: "which is be setup as part" -> "which will be set up as part"
- java/meters/dist-summary.md: "setup as part of application initialization" -> "set up as part of..."
- six java/ext/jvm-*.md pages: "just setup registration" -> "just set up registration"

Awkward phrasing:
- concepts/time-series.md: clarified "In casual language about Atlas metric is often used interchangeably with..." by italicizing the bare noun ("*metric*") and adding the comma so the sentence parses.
- overview.md: dropped a stray "retain" in "still retain successfully publish most data" -> "still successfully publish most data".
- go/migrations.md and api/graph/color-palettes.md: double-space cleanups.