### PR TITLE
asl: docs for distinct count sketch operators

### DIFF
--- a/docs/asl/ref/approx-distinct-cumulative.md
+++ b/docs/asl/ref/approx-distinct-cumulative.md
@@ -1,0 +1,85 @@
+@@@ atlas-signature
+expr: TimeSeriesExpr
+-->
+TimeSeriesExpr
+@@@
+
+Estimate the number of distinct values seen from the start of the graph window up to each point
+in time. Where [:approx-distinct](approx-distinct.md) estimates each interval on its own, this
+gives a running total of everything seen so far, so the line never decreases.
+
+For a live event, `:approx-distinct` answers "how many people are watching right now" and
+`:approx-distinct-cumulative` answers "how many people have watched at all". The two differ by
+however much the audience turns over: if viewers join and leave, more people watch over the
+event than are ever watching at once.
+
+## Parameters
+
+* **expr**: A query for a metric published as a distinct count sketch. See
+  [:approx-distinct](approx-distinct.md) for how to publish it
+
+## Behavior
+
+* **Non-decreasing**: Each value covers everything from the start of the window, so the line
+  only rises or stays flat
+* **Depends on the time range**: The count starts over at the start of the graph window.
+  Widening the range raises the values, because more history is included, so the number is
+  only meaningful alongside the window it was taken over
+* **The count is approximate**: The same accuracy applies as for
+  [:approx-distinct](approx-distinct.md), a relative standard error of roughly 13%. The running
+  total is smoother than the per interval estimate but no more accurate
+* **Grouping**: Add `(,key,),:by` before the operation to get a running count per group. As
+  with [:approx-distinct](approx-distinct.md), the groups only add up when a distinct value can
+  appear in just one group
+
+## How It Works
+
+The operation is a rewrite of:
+
+```
+:dup,:cumulative-max,:approx-distinct
+```
+
+Sketches merge by taking the max of each register, so applying
+[:cumulative-max](cumulative-max.md) to the registers unions the sketches across time before
+the estimate is computed. The running max has to be applied to the registers, not to the
+estimates, which is why this is a distinct operation rather than something to assemble by hand.
+
+## Examples
+
+The total audience next to the audience at any one time, for the live event in the sample data.
+The gap between the lines is the turnover: 2.18M viewers over the event against a peak of 1.90M
+watching at once:
+
+@@@ atlas-graph { show-expr=true }
+/api/v1/graph?w=750&h=200&l=0&s=e-6h&e=2012-01-01T00:00&tz=UTC&q=name,viewers.concurrent,:eq,:sum,:dup,:approx-distinct,active+now,:legend,:swap,:approx-distinct-cumulative,seen+so+far,:legend
+@@@
+
+Running count broken out by device:
+
+@@@ atlas-graph { show-expr=true }
+/api/v1/graph?w=750&h=200&l=0&s=e-6h&e=2012-01-01T00:00&tz=UTC&q=name,viewers.concurrent,:eq,:sum,(,device,),:by,:approx-distinct-cumulative
+@@@
+
+## Order Matters
+
+Applying [:cumulative-max](cumulative-max.md) to the output of
+[:approx-distinct](approx-distinct.md) looks similar but answers a different question. It gives
+the highest number ever seen at one time, which is smaller than the total seen over the window:
+
+@@@ atlas-graph { show-expr=true }
+/api/v1/graph?w=750&h=200&l=0&s=e-6h&e=2012-01-01T00:00&tz=UTC&q=name,viewers.concurrent,:eq,:sum,:dup,:approx-distinct-cumulative,total+seen,:legend,:swap,:approx-distinct,:cumulative-max,peak+at+one+time,:legend
+@@@
+
+Use `:approx-distinct-cumulative` for the running total. To track the peak, applying
+`:cumulative-max` after `:approx-distinct` is the correct form and is worth plotting alongside
+the total.
+
+## Related Operations
+
+* [:approx-distinct](approx-distinct.md) - Distinct values per interval
+* [:cumulative-max](cumulative-max.md) - Running maximum of a line
+* [:integral](integral.md) - Running sum, the equivalent for values that add up
+* [:by](by.md) - Break the running count out by a key
+
+Since: 1.9

--- a/docs/asl/ref/approx-distinct.md
+++ b/docs/asl/ref/approx-distinct.md
@@ -1,0 +1,84 @@
+@@@ atlas-signature
+expr: TimeSeriesExpr
+-->
+TimeSeriesExpr
+@@@
+
+Estimate the number of distinct values seen in each interval, for example the number of
+distinct users active on a service. Counting distinct values exactly means remembering every
+value seen, which does not fit in a time series, so the count is approximate.
+
+Each output datapoint is the estimate for that interval on its own. For a running count of the
+distinct values seen so far, use
+[:approx-distinct-cumulative](approx-distinct-cumulative.md).
+
+## Parameters
+
+* **expr**: A query for a metric published as a distinct count sketch
+
+## Publishing the Data
+
+This operation only works on data published for it. The
+[spectator](http://netflix.github.io/spectator/en/latest/) `DistinctCountSketch` class records
+values into a [HyperLogLog] sketch and publishes it as a fixed set of 64 max gauges, one per
+register, tagged with `statistic=distinct` and a `distinct=R##` register id. Query the metric
+by name as usual and let `:approx-distinct` reassemble the registers.
+
+[HyperLogLog]: https://en.wikipedia.org/wiki/HyperLogLog
+
+Applying `:approx-distinct` to an ordinary metric matches nothing, because the query is
+rewritten to require the register tag. A sketch costs 64 time series per source, so any
+additional dimensions on it need a small, bounded cardinality, the same as for a percentile
+timer.
+
+## Behavior
+
+* **The count is approximate**: The relative standard error is roughly 13%, so expect the value
+  to move around a little from one interval to the next even when the true count is steady. Use
+  it to see the magnitude and the shape of a trend, not to read off an exact number
+* **Merges across sources**: The registers are merged across everything the query matches, by
+  taking the max per register, before a single estimate is computed. A user active on several
+  instances counts once, so the result is not the sum of the per instance counts
+* **Per interval**: Each interval is estimated on its own, so the line goes down as well as up
+* **Aggregation is optional**: The estimator reshapes the input to the register grouping itself,
+  so `:sum` is not required. Aggregates that cannot be regrouped, such as `:avg` and `:count`,
+  are rejected, as is `:all`
+* **Grouping**: Add `(,key,),:by` before the operation to estimate separately for each value of
+  a key
+
+## Examples
+
+The sample data has a metric for a live event that runs once a day, with the audience joining
+over the first half hour, turning over while the event runs, and leaving at the end:
+
+@@@ atlas-graph { show-expr=true }
+/api/v1/graph?w=750&h=200&l=0&s=e-6h&e=2012-01-01T00:00&tz=UTC&q=name,viewers.concurrent,:eq,:sum,:approx-distinct,active+viewers,:legend
+@@@
+
+Break the estimate out by device:
+
+@@@ atlas-graph { show-expr=true }
+/api/v1/graph?w=750&h=200&l=0&s=e-6h&e=2012-01-01T00:00&tz=UTC&q=name,viewers.concurrent,:eq,:sum,(,device,),:by,:approx-distinct
+@@@
+
+## Groups May Not Add Up
+
+The grouped estimates only total the ungrouped estimate when each distinct value can appear in
+just one group. In the example above a viewer watches on one device, so the devices roughly add
+up to the overall count. Group by something a viewer can be in more than once, such as the
+titles watched, and the groups will total more than the ungrouped estimate: the viewer counts
+once overall but once in each group they appear in.
+
+This is a property of counting distinct things, not of the approximation. Summing the groups
+answers a different question from estimating over everything at once, so aggregating the result
+of `:approx-distinct` with `:sum` is nearly always a mistake. Put the grouping before the
+operation and let it do the merging.
+
+## Related Operations
+
+* [:approx-distinct-cumulative](approx-distinct-cumulative.md) - Distinct values seen so far,
+  rather than per interval
+* [:by](by.md) - Break the estimate out by a key
+* [:count](count.md) - Number of lines matched, which is not the number of distinct values
+
+Since: 1.9

--- a/docs/asl/ref/cumulative-max.md
+++ b/docs/asl/ref/cumulative-max.md
@@ -1,0 +1,71 @@
+@@@ atlas-signature
+expr: TimeSeriesExpr
+-->
+TimeSeriesExpr
+@@@
+
+Compute the running maximum of a time series across the evaluation time window. Each output
+datapoint is the largest value seen on the input line from the start of the graph up to the
+time for that datapoint, so the result never decreases.
+
+This is the max analogue of [:integral](integral.md): a running value from the start of the
+window, rather than a sliding window like [:rolling-max](rolling-max.md).
+
+## Parameters
+
+* **expr**: The time series expression to compute the running maximum of
+
+## Behavior
+
+* **Non-decreasing**: Each value is the maximum of the input up to that point, so the output
+  only ever rises or stays flat
+* **Missing data**: NaN values are ignored and leave the running maximum unchanged
+* **Window relative**: The running maximum starts over at the beginning of the graph window,
+  so changing the time range changes the result
+* **No leading NaN**: Unlike the rolling operations, there is no window to fill, so the first
+  datapoint is already the maximum of the input up to that point
+
+## Data Processing
+
+| Input | :cumulative-max |
+|-------|-----------------|
+| 1     | 1               |
+| 2     | 2               |
+| 0     | 2               |
+| NaN   | 2               |
+| 5     | 5               |
+| 3     | 5               |
+
+## Peak So Far
+
+The common use is showing the worst value seen so far next to the current value. The two lines
+meet whenever the input is setting a new peak, and the running maximum holds flat afterwards:
+
+@@@ atlas-graph { show-expr=true }
+/api/v1/graph?w=750&h=200&l=0&s=e-18h&e=2012-01-01T12:00&tz=UTC&q=name,sps,:eq,:sum,:dup,:cumulative-max,peak+so+far,:legend,:swap,sps,:legend
+@@@
+
+The same shape applied to the number of viewers of a live event, where the peak reached during
+the event is held after the audience leaves:
+
+@@@ atlas-graph { show-expr=true }
+/api/v1/graph?w=750&h=200&l=0&s=e-6h&e=2012-01-01T00:00&tz=UTC&q=name,viewers.concurrent,:eq,:sum,:approx-distinct,:dup,:cumulative-max,peak+so+far,:legend,:swap,active+viewers,:legend
+@@@
+
+## Distinct Counts
+
+To get a running count of distinct values, use
+[:approx-distinct-cumulative](approx-distinct-cumulative.md) rather than applying
+`:cumulative-max` to a distinct count. As shown above, applying it to the output of
+[:approx-distinct](approx-distinct.md) gives the highest count seen at any one time, which is
+not the same as the total number seen over the window.
+
+## Related Operations
+
+* [:rolling-max](rolling-max.md) - Maximum over a sliding window of datapoints
+* [:max](max.md) - Maximum across lines at each interval, not across time
+* [:integral](integral.md) - Running sum across the window
+* [:approx-distinct-cumulative](approx-distinct-cumulative.md) - Running count of distinct
+  values
+
+Since: 1.9

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,8 @@ nav:
       - abs: asl/ref/abs.md
       - add: asl/ref/add.md
       - and: asl/ref/and.md
+      - approx-distinct: asl/ref/approx-distinct.md
+      - approx-distinct-cumulative: asl/ref/approx-distinct-cumulative.md
       - as: asl/ref/as.md
       - avg: asl/ref/avg.md
       - bottomk: asl/ref/bottomk.md
@@ -92,6 +94,7 @@ nav:
       - const: asl/ref/const.md
       - count: asl/ref/count.md
       - cq: asl/ref/cq.md
+      - cumulative-max: asl/ref/cumulative-max.md
       - delay: asl/ref/delay.md
       - derivative: asl/ref/derivative.md
       - des: asl/ref/des.md

--- a/plugins/mkdocs-atlas-formatting-plugin/mkdocs_atlas_formatting_plugin/config.py
+++ b/plugins/mkdocs-atlas-formatting-plugin/mkdocs_atlas_formatting_plugin/config.py
@@ -2,4 +2,4 @@
 PLUGIN_NAME = 'atlas_formatting'
 
 # version of the latest atlas standalone release
-ATLAS_VERSION = '1.9.0-rc.15'
+ATLAS_VERSION = '1.9.0-rc.20'


### PR DESCRIPTION
Add reference pages for :approx-distinct, :approx-distinct-cumulative, and :cumulative-max, with graphs rendered from the live event viewers sample data added in Netflix/atlas#1984. Bumps the standalone version used to build the docs to 1.9.0-rc.20 so that data is available.