### PR TITLE
spectator: document distinct count sketch for java

### DIFF
--- a/docs/asl/ref/approx-distinct-cumulative.md
+++ b/docs/asl/ref/approx-distinct-cumulative.md
@@ -32,19 +32,6 @@ event than are ever watching at once.
   with [:approx-distinct](approx-distinct.md), the groups only add up when a distinct value can
   appear in just one group
 
-## How It Works
-
-The operation is a rewrite of:
-
-```
-:dup,:cumulative-max,:approx-distinct
-```
-
-Sketches merge by taking the max of each register, so applying
-[:cumulative-max](cumulative-max.md) to the registers unions the sketches across time before
-the estimate is computed. The running max has to be applied to the registers, not to the
-estimates, which is why this is a distinct operation rather than something to assemble by hand.
-
 ## Examples
 
 The total audience next to the audience at any one time, for the live event in the sample data.

--- a/docs/asl/ref/approx-distinct.md
+++ b/docs/asl/ref/approx-distinct.md
@@ -18,31 +18,21 @@ distinct values seen so far, use
 
 ## Publishing the Data
 
-This operation only works on data published for it. The
-[spectator](http://netflix.github.io/spectator/en/latest/) `DistinctCountSketch` class records
-values into a [HyperLogLog] sketch and publishes it as a fixed set of 64 max gauges, one per
-register, tagged with `statistic=distinct` and a `distinct=R##` register id. Query the metric
-by name as usual and let `:approx-distinct` reassemble the registers.
-
-[HyperLogLog]: https://en.wikipedia.org/wiki/HyperLogLog
-
-Applying `:approx-distinct` to an ordinary metric matches nothing, because the query is
-rewritten to require the register tag. A sketch costs 64 time series per source, so any
-additional dimensions on it need a small, bounded cardinality, the same as for a percentile
-timer.
+This operation only works on data published for it, with a
+[Distinct Count Sketch](../../spectator/lang/java/patterns/distinct-count-sketch.md). Query the
+metric by name as usual. Applying `:approx-distinct` to an ordinary metric matches nothing.
 
 ## Behavior
 
 * **The count is approximate**: The relative standard error is roughly 13%, so expect the value
   to move around a little from one interval to the next even when the true count is steady. Use
   it to see the magnitude and the shape of a trend, not to read off an exact number
-* **Merges across sources**: The registers are merged across everything the query matches, by
-  taking the max per register, before a single estimate is computed. A user active on several
-  instances counts once, so the result is not the sum of the per instance counts
+* **Merges across sources**: A single estimate is computed over everything the query matches. A
+  user active on several instances counts once, so the result is not the sum of the per instance
+  counts
 * **Per interval**: Each interval is estimated on its own, so the line goes down as well as up
-* **Aggregation is optional**: The estimator reshapes the input to the register grouping itself,
-  so `:sum` is not required. Aggregates that cannot be regrouped, such as `:avg` and `:count`,
-  are rejected, as is `:all`
+* **Aggregation is optional**: `:sum` is not required, it makes no difference to the estimate.
+  `:avg`, `:count`, and `:all` are rejected
 * **Grouping**: Add `(,key,),:by` before the operation to estimate separately for each value of
   a key
 

--- a/docs/spectator/lang/java/patterns/distinct-count-sketch.md
+++ b/docs/spectator/lang/java/patterns/distinct-count-sketch.md
@@ -1,0 +1,98 @@
+# Distinct Count Sketch
+
+`DistinctCountSketch` estimates the number of distinct values seen during a reporting interval,
+for example unique users, device ids, or source ips. Counting distinct values exactly means
+remembering every value seen, which does not fit in a metric, so the sketch trades exactness for
+a fixed cost: recording a value is constant time and allocation free, and the metric costs the
+same whether there are ten distinct values or ten million.
+
+Example:
+
+```java
+public class WebServer {
+
+  private final DistinctCountSketch uniqueUsers;
+
+  @Inject
+  public WebServer(Registry registry) {
+    uniqueUsers = DistinctCountSketch.get(registry, registry.createId("server.uniqueUsers"));
+  }
+
+  public Response handleRequest(Request req) {
+    uniqueUsers.record(req.getUserId());
+    return doSomething(req);
+  }
+}
+```
+
+Then query the number of distinct users active in each interval:
+
+```
+name,server.uniqueUsers,:eq,:approx-distinct
+```
+
+The estimate covers everything the query matches, so a user active on several instances counts
+once rather than once per instance. Nothing needs to be done at record time to make that work.
+
+## Recording Values
+
+There are overloads for the common shapes of an id:
+
+```java
+sketch.record(userId);          // long, such as a numeric id
+sketch.record(sessionId);       // CharSequence, such as a string id or ip address
+sketch.record(rawBytes);        // byte[]
+```
+
+The values themselves are never published, only what is needed to estimate how many of them were
+distinct. Equal values have to be recorded the same way to be counted once, so normalize the
+input consistently at every call site: record either the raw ip string or the parsed bytes, not
+a mix of the two.
+
+## Additional Dimensions
+
+Use the builder to add tags, including ones that vary at the call site:
+
+```java
+DistinctCountSketch.builder(registry)
+  .withName("server.uniqueUsers")
+  .withTag("device", device)
+  .build()
+  .record(userId);
+```
+
+The estimate can then be broken out by that dimension at query time:
+
+```
+name,server.uniqueUsers,:eq,(,device,),:by,:approx-distinct
+```
+
+The grouped estimates only total the ungrouped estimate when a value can belong to just one
+group. A user active on both a phone and a TV counts once overall, but once in each of those
+groups.
+
+## Cost
+
+**A distinct count sketch is much more expensive than a plain counter.** One sketch costs 64
+time series per instance, and that is multiplied by every other tag on the id. Be as diligent
+about the dimensions on a sketch as for a percentile timer, and use a
+[cardinality limiter](cardinality-limiter.md) for any tag value that is not strictly bounded.
+
+## Accuracy
+
+The result is an estimate, not an exact count. The relative standard error is roughly 13%, so
+the value moves around a little from interval to interval even when the true count is steady, and
+the precision is fixed rather than something to tune. Use it for the magnitude and the shape of a
+trend, not to read off an exact number.
+
+`sketch.cardinality()` estimates the distinct count for what was recorded into that instance,
+which is useful in tests and local debugging. It says nothing about the fleet-wide count, which
+is computed across all sources at query time.
+
+## Querying
+
+* [:approx-distinct] - distinct values in each interval
+* [:approx-distinct-cumulative] - running count of the distinct values seen so far
+
+[:approx-distinct]: ../../../../asl/ref/approx-distinct.md
+[:approx-distinct-cumulative]: ../../../../asl/ref/approx-distinct-cumulative.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -276,6 +276,7 @@ nav:
         - Timer: spectator/lang/java/meters/timer.md
       - Patterns:
         - Cardinality Limiter: spectator/lang/java/patterns/cardinality-limiter.md
+        - Distinct Count Sketch: spectator/lang/java/patterns/distinct-count-sketch.md
         - Interval Counter: spectator/lang/java/patterns/interval-counter.md
         - Long Task Timer: spectator/lang/java/patterns/long-task-timer.md
         - Polled Meter: spectator/lang/java/patterns/polled-meter.md


### PR DESCRIPTION
Add a Java pattern page for DistinctCountSketch covering how to record values, adding dimensions, the cost, and the accuracy of the estimate.

Also drops the implementation details from the :approx-distinct pages, such as the register encoding and tagging, in favor of linking to the spectator page. Readers need to know how to publish and query the data, not how the sketch is encoded.